### PR TITLE
prepare test-kitchen tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,20 +1,62 @@
 ---
 driver:
-  name: vagrant
-  network:
-    - ["private_network", {ip: '192.168.33.202'}]
+  name: dokken
+  chef_version: 12.5.1
+  privileged: true # because Docker and SystemD/Upstart
+
+transport:
+  name: dokken
 
 provisioner:
-  name: chef_zero
+  name: dokken
 
-# Uncomment the following verifier to leverage Inspec instead of Busser (the
-# default verifier)
-# verifier:
-#   name: inspec
+verifier:
+  name: inspec
+  sudo: false
 
 platforms:
-  - name: ubuntu-14.04
-  - name: centos-7.1
+- name: ubuntu-12.04
+  driver:
+    image: ubuntu:12.04
+- name: ubuntu-14.04
+  driver:
+    image: ubuntu:14.04
+- name: ubuntu-15.10
+  driver:
+    image: ubuntu:15.10
+    pid_one_command: /bin/systemd
+- name: centos-6.6
+  driver:
+    image: centos:6.6
+- name: centos-6.7
+  driver:
+    image: centos:6.7
+    intermediate_instructions:
+      - RUN yum install -y initscripts
+- name: centos-7
+  driver:
+    image: centos:7
+    pid_one_command: /usr/lib/systemd/systemd
+- name: oracle-6.6
+  driver:
+    image: oraclelinux:6.6
+- name: oracle-6.7
+  driver:
+    image: oraclelinux:6.7
+- name: oracle-7.1
+  driver:
+    image: oraclelinux:7.1
+    pid_one_command: /usr/lib/systemd/systemd
+- name: debian-7
+  driver:
+    image: debian:7
+    intermediate_instructions:
+    - RUN /usr/bin/apt-get update
+    - RUN /usr/bin/apt-get install -y procps
+- name: debian-8
+  driver:
+    image: debian:8
+    pid_one_command: /bin/systemd
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,14 @@
 language: ruby
 cache: bundler
 
-rvm:
-- 2.1.3
-bundler_args: "--without integration"
-gemfile:
-- Gemfile
+# necessary for docker to work
+sudo: required
+dist: trusty
+services:
+  - docker
+
+matrix:
+  include:
+    - rvm: 2.2
+      bundler_args: "--without integration"
+      script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,6 @@ end
 
 group :integration do
   gem 'test-kitchen', '~> 1.6'
+  gem 'kitchen-dokken'
+  gem 'kitchen-inspec', '~> 0.9'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -35,3 +35,11 @@ desc 'Find notes in code'
 task :notes do
   puts `egrep --exclude=Rakefile --exclude=*.log -n -r -i '(TODO|FIXME|OPTIMIZE)' .`
 end
+
+namespace :test do
+  task :integration do
+    concurrency = ENV['CONCURRENCY'] || 1
+    path = File.join(File.dirname(__FILE__), 'test', 'integration')
+    sh('sh', '-c', "bundle exec kitchen test -c #{concurrency}")
+  end
+end


### PR DESCRIPTION
This PR prepares the run of kitchen tests with `kitchen-dokken`. We need to add the following to make this fully working:
- add some kind of mock profile
- a mock backend that retrieves the reports

Lets add those in separate PRs.
