### PR TITLE
Use move to avoid cross-device error

### DIFF
--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require 'tempfile'
 require 'uri'
+require 'fileutils'
 
 # `compliance_profile` custom resource to collect and run Chef Compliance
 # profiles
@@ -59,8 +60,7 @@ class ComplianceProfile < Chef::Resource
       path = tar_path
       directory(::Pathname.new(path).dirname.to_s).run_action(:create)
 
-      ::File.rename(tf.path, path)
-      # tf.unlink
+      FileUtils.move(tf.path, path)
     end
   end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ description 'Allows for fetching and executing compliance profiles, and '\
 source_url 'https://github.com/chef-cookbooks/audit' if defined?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/audit/issues' if defined?(:issues_url)
 
-version '0.3.2'
+version '0.3.3'


### PR DESCRIPTION
File rename won't work across devices, throwing an "Invalid cross-device link" exception.

Thanks Marcus for reporting the issue!