### PR TITLE
adding ability to handle offline compliance server

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,5 +22,5 @@ default['audit']['profiles'] = {}
 # while fetching profiles or posting report
 default['audit']['raise_if_unreachable'] = false
 
-# raise exception if no profile is present on node
-default['audit']['raise_if_not_present'] = true
+# fail converge if downloaded profile is not present
+default['audit']['fail_if_not_present'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,3 +17,10 @@
 #
 
 default['audit']['profiles'] = {}
+
+# raise exception if Compliance API endpoint is unreachable
+# while fetching profiles or posting report
+default['audit']['raise_if_unreachable'] = false
+
+# raise exception if no profile is present on node
+default['audit']['raise_if_not_present'] = true

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -91,7 +91,7 @@ class ComplianceProfile < Chef::Resource
 
       unless ::File.exist?(path)
         Chef::Log.warn "No such file: #{path}"
-        raise "Aborting since profile is not present here: #{path}" if run_context.node.audit.raise_if_not_present
+        fail "Aborting since profile is not present here: #{path}" if run_context.node.audit.fail_if_not_present
         return
       end
 

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -34,7 +34,18 @@ class ComplianceReport < Chef::Resource
       url = construct_url(::File.join('/organizations', org, 'inspec'))
       # Chef::Log.debug "url: #{url}"
       rest = Chef::ServerAPI.new(url, Chef::Config)
-      rest.post(url, blob)
+      begin
+        rest.post(url, blob)
+      rescue Net::HTTPServerException => e
+        case e.message
+        when /401/
+          Chef::Log.error "#{e} Possible time/date issue on the client."
+        when /403/
+          Chef::Log.error "#{e} Possible offline Compliance Server or chef_gate auth issue."
+        end
+        Chef::Log.error 'Report NOT saved to server.'
+        raise e if run_context.node.audit.raise_if_unreachable
+      end
     end
   end
 

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -61,6 +61,7 @@ class ComplianceReport < Chef::Resource
     ownermap = {}
 
     profiles.flatten.each do |prof|
+      next unless ::File.exist?(prof.report_path)
       o, p = prof.normalize_owner_profile
       report[p] = ::JSON.parse(::File.read(prof.report_path))
       ownermap[p] = o


### PR DESCRIPTION
While testing I noticed a couple of scenarios:

1. A client with a time/date skew simply getting a "401 Unauthorized" error while attempting to download profiles failing the converge.
2. A client failing to converge if the Compliance server API was unavailable.

These changes give the ability to handle these exceptions and allow the node to still continue with the rest of the converge.