### PR TITLE
update inspec gem version pin

### DIFF
--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -23,7 +23,7 @@ class ComplianceProfile < Chef::Resource # rubocop:disable Metrics/ClassLength
   # e.g. for running profiles from disk (coming from some other source)
   property :path, String
 
-  inspec_version = '0.19.1'
+  inspec_version = '0.19.3'
 
   default_action :execute
 


### PR DESCRIPTION
### Description

There was an issue with inspec gem causing TypeError
```
  ================================================================================
    Error executing action `execute` on resource 'compliance_profile[linux]'
    ================================================================================

    TypeError
    ---------
    no implicit conversion of Symbol into Integer
```
It was fixed here: https://github.com/chef/inspec/pull/679

### Issues Resolved

https://github.com/chef/inspec/pull/679

The new gem version (0.19.3) was released here: https://github.com/chef/inspec/pull/680

Tested converging the audit cookbook with inspec v0.19.3 and the issue is resolved.