### PR TITLE
Add profile name validation and unit tests

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 
 # used by ChefSpec
 if defined?(ChefSpec)

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,18 @@
+
+# used by ChefSpec
+if defined?(ChefSpec)
+
+  ChefSpec.define_matcher :compliance_profile
+
+  def fetch_compliance_profile(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:compliance_profile, :fetch, resource_name)
+  end
+
+  def execute_compliance_profile(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:compliance_profile, :execute, resource_name)
+  end
+
+  def execute_compliance_report(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:compliance_report, :execute, resource_name)
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ description 'Allows for fetching and executing compliance profiles, and '\
 source_url 'https://github.com/chef-cookbooks/audit' if defined?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/audit/issues' if defined?(:issues_url)
 
-version '0.5.1'
+version '0.6.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,8 @@ server = node['audit']['server']
 # iterate over all selected profiles
 node['audit']['profiles'].each do |owner_profile, enabled|
   next unless enabled
+  fail "Invalid profile name '#{owner_profile}'. "+
+       "Must contain /, e.g. 'john/ssh'" if owner_profile !~ /\//
   o, p = owner_profile.split('/')
 
   compliance_profile p do
@@ -36,8 +38,9 @@ end
 
 # report the results
 compliance_report 'chef-server' do
+  owner node['audit']['owner']
   server server
   token token
-  owner node['audit']['owner']
   variant node['audit']['variant']
+  action :execute
 end if node['audit']['profiles'].values.any?

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,8 +23,8 @@ server = node['audit']['server']
 # iterate over all selected profiles
 node['audit']['profiles'].each do |owner_profile, enabled|
   next unless enabled
-  fail "Invalid profile name '#{owner_profile}'. "+
-       "Must contain /, e.g. 'john/ssh'" if owner_profile !~ /\//
+  fail "Invalid profile name '#{owner_profile}'. "\
+       "Must contain /, e.g. 'john/ssh'" if owner_profile !~ %r{\/}
   o, p = owner_profile.split('/')
 
   compliance_profile p do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -22,12 +22,59 @@ require 'spec_helper'
 describe 'audit::default' do
   context 'When all attributes are default, on an unspecified platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04')
       runner.converge(described_recipe)
     end
 
     it 'converges successfully' do
       expect { chef_run }.to_not raise_error
+    end
+  end
+
+
+  context 'When two profiles are specified' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.5')
+      runner.node.set['audit']['profiles'] = { "admin/myprofile" => true,
+                                               "base/ssh" => false }
+      runner.converge(described_recipe)
+    end
+
+    it 'runs the compliance_profile' do
+      expect(chef_run).to fetch_compliance_profile('myprofile').with(
+          owner: 'admin',
+          server: nil,
+          token: nil,
+          inspec_version: 'latest'
+        )
+      expect(chef_run).to execute_compliance_profile('myprofile').with(
+          owner: 'admin',
+          server: nil,
+          token: nil,
+          inspec_version: 'latest'
+        )
+      expect(chef_run).to execute_compliance_report('chef-server').with(
+          owner: nil,
+          server: nil,
+          token: nil,
+          variant: 'chef'
+        )
+    end
+
+    it 'converges successfully' do
+      expect{chef_run}.to_not raise_error
+    end
+  end
+
+  context 'When invalid profile is passed' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.5')
+      runner.node.set['audit']['profiles'] = { "myprofile" => true }
+      runner.converge(described_recipe)
+    end
+
+    it 'does raise an error' do
+      expect{chef_run}.to raise_error("Invalid profile name 'myprofile'. Must contain /, e.g. 'john/ssh'")
     end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -31,34 +31,33 @@ describe 'audit::default' do
     end
   end
 
-
   context 'When two profiles are specified' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.5')
-      runner.node.set['audit']['profiles'] = { "admin/myprofile" => true,
-                                               "base/ssh" => false }
+      runner.node.set['audit']['profiles'] = { 'admin/myprofile' => true,
+                                               'base/ssh' => false }
       runner.converge(described_recipe)
     end
 
     it 'fetches and executes compliance_profile[myprofile]' do
       expect(chef_run).to fetch_compliance_profile('myprofile').with(
-          owner: 'admin',
-          server: nil,
-          token: nil,
-          inspec_version: 'latest'
-        )
+        owner: 'admin',
+        server: nil,
+        token: nil,
+        inspec_version: 'latest',
+      )
       expect(chef_run).to execute_compliance_profile('myprofile').with(
-          owner: 'admin',
-          server: nil,
-          token: nil,
-          inspec_version: 'latest'
-        )
+        owner: 'admin',
+        server: nil,
+        token: nil,
+        inspec_version: 'latest',
+      )
       expect(chef_run).to execute_compliance_report('chef-server').with(
-          owner: nil,
-          server: nil,
-          token: nil,
-          variant: 'chef'
-        )
+        owner: nil,
+        server: nil,
+        token: nil,
+        variant: 'chef',
+      )
     end
 
     it 'skips compliance_profile[ssh]' do
@@ -67,20 +66,19 @@ describe 'audit::default' do
     end
 
     it 'converges successfully' do
-      expect{chef_run}.to_not raise_error
+      expect { chef_run }.to_not raise_error
     end
   end
-
 
   context 'When invalid profile is passed' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.5')
-      runner.node.set['audit']['profiles'] = { "myprofile" => true }
+      runner.node.set['audit']['profiles'] = { 'myprofile' => true }
       runner.converge(described_recipe)
     end
 
     it 'does raise an error' do
-      expect{chef_run}.to raise_error("Invalid profile name 'myprofile'. Must contain /, e.g. 'john/ssh'")
+      expect { chef_run }.to raise_error("Invalid profile name 'myprofile'. Must contain /, e.g. 'john/ssh'")
     end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -40,7 +40,7 @@ describe 'audit::default' do
       runner.converge(described_recipe)
     end
 
-    it 'runs the compliance_profile' do
+    it 'fetches and executes compliance_profile[myprofile]' do
       expect(chef_run).to fetch_compliance_profile('myprofile').with(
           owner: 'admin',
           server: nil,
@@ -61,10 +61,16 @@ describe 'audit::default' do
         )
     end
 
+    it 'skips compliance_profile[ssh]' do
+      expect(chef_run).to_not fetch_compliance_profile('ssh')
+      expect(chef_run).to_not execute_compliance_profile('ssh')
+    end
+
     it 'converges successfully' do
       expect{chef_run}.to_not raise_error
     end
   end
+
 
   context 'When invalid profile is passed' do
     let(:chef_run) do


### PR DESCRIPTION
Give a more descriptive error message if the profile name provided is invalid:

```bash
RuntimeError
------------
Invalid profile name 'mylinux'. Must contain /, e.g. 'john/ssh'
```

Adds unit tests for this case, but also for correct profile names