### PR TITLE
fix: use_ssl value has changed error

### DIFF
--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -52,10 +52,11 @@ class ComplianceProfile < Chef::Resource # rubocop:disable Metrics/ClassLength
 
         tf = Tempfile.new('foo', Dir.tmpdir, 'wb+')
         tf.binmode
-        Net::HTTP.start(url.host, url.port) do |http|
-          http.use_ssl = url.scheme == 'https'
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE # FIXME
 
+        opts = { use_ssl: url.scheme == 'https',
+                 verify_mode: OpenSSL::SSL::VERIFY_NONE, # FIXME
+        }
+        Net::HTTP.start(url.host, url.port, opts) do |http|
           resp = with_http_rescue do
             http.get(url.path, 'Authorization' => "Bearer #{token}")
           end

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -43,10 +43,10 @@ class ComplianceReport < Chef::Resource
         req = Net::HTTP::Post.new(url, { 'Authorization' => "Bearer #{token}" })
         req.body = blob.to_json
 
-        Net::HTTP.start(url.host, url.port) do |http|
-          http.use_ssl = url.scheme == 'https'
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE # FIXME
-
+        opts = { use_ssl: url.scheme == 'https',
+                 verify_mode: OpenSSL::SSL::VERIFY_NONE, # FIXME
+        }
+        Net::HTTP.start(url.host, url.port, opts) do |http|
           with_http_rescue do
             http.request(req)
           end


### PR DESCRIPTION
### Description

When using the token and communicating directly with the Compliance Server one will encounter this error:

```
           IOError
           -------
           use_ssl value changed, but session already started
```

### Issues Resolved

This change fixes the above error by setting the use_ssl options within the Net::HTTP.start() method, not afterwards.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

