### PR TITLE
quiet mode for inspec scans

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@ default['audit']['server'] = nil
 default['audit']['token'] = nil
 default['audit']['variant'] = 'chef'
 default['audit']['owner'] = nil
+default['audit']['quiet'] = nil
 default['audit']['profiles'] = {}
 
 # raise exception if Compliance API endpoint is unreachable

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -18,6 +18,7 @@ class ComplianceProfile < Chef::Resource # rubocop:disable Metrics/ClassLength
   property :port, Integer
   property :token, [String, nil]
   property :inspec_version, String, default: 'latest'
+  property :quiet, [TrueClass, FalseClass], default: true
   # TODO(sr) it might be nice to default to settings from attributes
 
   # alternative to (owner, profile)-addressing for profiles,
@@ -107,7 +108,8 @@ class ComplianceProfile < Chef::Resource # rubocop:disable Metrics/ClassLength
 
       # TODO: flesh out inspec's report CLI interface,
       #       make this an execute[inspec check ...]
-      runner = ::Inspec::Runner.new('report' => true, 'format' => 'json-min')
+      output = quiet ? ::File::NULL : $stdout
+      runner = ::Inspec::Runner.new('report' => true, 'format' => 'json-min', 'output' => output)
       runner.add_target(path, {})
       begin
         runner.run

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -12,6 +12,7 @@ class ComplianceReport < Chef::Resource
   property :port, Integer
   property :token, [String, nil]
   property :variant, String, default: 'chef' # 'chef', 'compliance'
+  property :quiet, [TrueClass, FalseClass], default: true
 
   property :environment, String # default: node.environment
   property :owner, [String, nil]
@@ -25,7 +26,10 @@ class ComplianceReport < Chef::Resource
       blob = node_info
       blob[:reports] = reports
       total_failed = 0
-      blob[:reports].each { |k, _| total_failed += blob[:reports][k]['summary']['failure_count'].to_i }
+      blob[:reports].each do |k, _|
+        Chef::Log.info "Summary for #{k} #{blob[:reports][k]['summary'].to_json}" if quiet
+        total_failed += blob[:reports][k]['summary']['failure_count'].to_i
+      end
       blob[:profiles] = ownermap
 
       # resolve owner

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,6 +32,7 @@ node['audit']['profiles'].each do |owner_profile, enabled|
     server server
     token token
     inspec_version node['audit']['inspec_version']
+    quiet node['audit']['quiet'] unless node['audit']['quiet'].nil?
     action [:fetch, :execute]
   end
 end
@@ -42,5 +43,6 @@ compliance_report 'chef-server' do
   server server
   token token
   variant node['audit']['variant']
+  quiet node['audit']['quiet'] unless node['audit']['quiet'].nil?
   action :execute
 end if node['audit']['profiles'].values.any?

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -36,6 +36,8 @@ describe 'audit::default' do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.5')
       runner.node.set['audit']['profiles'] = { 'admin/myprofile' => true,
                                                'base/ssh' => false }
+      runner.node.set['audit']['inspec_version'] = 'latest'
+      runner.node.set['audit']['quiet'] = true
       runner.converge(described_recipe)
     end
 
@@ -51,12 +53,14 @@ describe 'audit::default' do
         server: nil,
         token: nil,
         inspec_version: 'latest',
+        quiet: true,
       )
       expect(chef_run).to execute_compliance_report('chef-server').with(
         owner: nil,
         server: nil,
         token: nil,
         variant: 'chef',
+        quiet: true,
       )
     end
 


### PR DESCRIPTION
### Description

This changes the default behavior for inspec during the node converge by suppressing the scan result json report from STDOUT.  Various customers have remarked that the default scan results being dumped to STDOUT is too busy and clutters up the converge output. Users can choose to continue to get the json report output by toggling the attribute: `default['audit']['quiet'] = false`.  The default value is `true`.  When, set to `true`, a short scan result Summary for each profile is output when the `compliance_report` is executed. 

### Issues Resolved

N/A

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

