### PR TITLE
Support other sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,32 @@ Please ensure that `chef-cookbooks` is the parent directory of `audit` cookbook.
 
 Once the cookbook is available in Chef Server, you need to add the `audit::default` recipe to the run-list of each node. The profiles are selected via the `node['audit']['profiles']` attribute. For example, to run the `base/ssh` and `base/linux` profiles, you can define the attribute in a JSON-based role or environment file like this:
 
-```json
-  "audit": {
-    "inspec_version": "0.22.0",
-    "profiles": {
-      "base/ssh": true,
-      "base/linux": true
-    }
+```ruby
+  audit = {
+    "inspec_version" => "0.22.0",
+    "profiles" => {
+      # org / profile name
+      'base/linux' => true,
+      'brewinc/ssh-hardening' => {
+        # where inspec will fetch from
+        'source' => 'supermarket://hardening/ssh-hardening',
+        'key' => 'value',
+      },
+      # Windows path
+      'brewinc/win2012_audit' => {
+        # filesystem path
+        'source' => 'E:/profiles/win2012_audit',
+      },
+      'brewinc/tmp_compliance_profile' => {
+        # github
+        'source' => 'https://github.com/nathenharvey/tmp_compliance_profile',
+      },
+      # disable profile
+      'brewinc/tmp_compliance_profile-master' => {
+        'source' => '/tmp/tmp_compliance_profile-master',
+        'disabled' => true,
+      },
+    },
   }
 ```
 
@@ -100,7 +119,7 @@ can be re-written in InSpec as follows:
 
 ```
 # rename `control_group` to `control` and use a unique identifier
-control "blog-1" do                        
+control "blog-1" do
   title 'Check SSH Port'  # add the title from `control_group`
   # rename the old `control` to `describe`
   describe 'SSH' do
@@ -114,7 +133,7 @@ end
 or even simplified to:
 
 ```
-control "blog-1" do                        
+control "blog-1" do
   title 'SSH should be listening on port 22'
   describe port(22) do
     it { should be_listening }

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -22,13 +22,15 @@ module ComplianceHelpers
     begin
       return yield
     rescue Net::HTTPServerException => e
-      case e.message
+      case e.response.code
       when /401/
-        Chef::Log.error "#{e} Possible time/date issue on the client."
+        Chef::Log.error "Possible time/date issue on the client."
       when /403/
-        Chef::Log.error "#{e} Possible offline Compliance Server or chef_gate auth issue."
+        Chef::Log.error "Possible offline Compliance Server or chef_gate auth issue."
+      when /404/
+        Chef::Log.error "Object does not exist on remote server."
       end
-      Chef::Log.error 'Profile NOT downloaded. Will use cached version if available.'
+      Chef::Log.error e.message
       raise e if run_context.node.audit.raise_if_unreachable
     end
   end

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -35,8 +35,8 @@ class ComplianceProfile < Chef::Resource # rubocop:disable Metrics/ClassLength
         action :install
       end
 
-      # load the supermarket plugin
       require 'inspec'
+      # load the supermarket plugin
       require 'bundles/inspec-supermarket/api'
       require 'bundles/inspec-supermarket/target'
       check_inspec

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,16 +21,23 @@ token = node['audit']['token']
 server = node['audit']['server']
 
 # iterate over all selected profiles
-node['audit']['profiles'].each do |owner_profile, enabled|
-  next unless enabled
+node['audit']['profiles'].each do |owner_profile, value|
+  case value
+  when Hash
+    next if value['disabled']
+    path = value['source']
+  else
+    next if value == false
+  end
   fail "Invalid profile name '#{owner_profile}'. "\
        "Must contain /, e.g. 'john/ssh'" if owner_profile !~ %r{\/}
-  o, p = owner_profile.split('/')
+  o, p = owner_profile.split('/').last(2)
 
   compliance_profile p do
     owner o
     server server
     token token
+    path path unless path.nil?
     inspec_version node['audit']['inspec_version']
     quiet node['audit']['quiet'] unless node['audit']['quiet'].nil?
     action [:fetch, :execute]


### PR DESCRIPTION
### Description

This implementation provides the ability to execute audit profiles from various additional sources, relying on existing plugin capabilities of the inspec gem.
Specifically, these sources are now supported:
  * Supermarket
  * Local filesystem path
  * Github repo

### Issues Resolved

#49

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

