### PR TITLE
handle auth error

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,7 +25,7 @@ default['audit']['profiles'] = {}
 
 # raise exception if Compliance API endpoint is unreachable
 # while fetching profiles or posting report
-default['audit']['raise_if_unreachable'] = false
+default['audit']['raise_if_unreachable'] = true
 
 # fail converge if downloaded profile is not present
 default['audit']['fail_if_not_present'] = false

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -18,21 +18,29 @@ module ComplianceHelpers
     server
   end
 
+  def handle_http_error_code(code)
+    case code
+    when /401/
+      Chef::Log.error 'Possible time/date issue on the client.'
+    when /403/
+      Chef::Log.error 'Possible offline Compliance Server or chef_gate auth issue.'
+    when /404/
+      Chef::Log.error 'Object does not exist on remote server.'
+    end
+    msg = 'Could not fetch the profile. Verify the authentication (e.g. token) is set properly'
+    Chef::Log.error msg
+    fail msg if run_context.node.audit.raise_if_unreachable
+  end
+
   #rubocop:disable all
   def with_http_rescue(&block)
     begin
-      return yield
+      response = yield
+      # handle non 200 error codes, they are not raised as Net::HTTPServerException
+      handle_http_error_code(response.code) if response.code.to_i >= 300
+      return response
     rescue Net::HTTPServerException => e
-      case e.response.code
-      when /401/
-        Chef::Log.error "Possible time/date issue on the client."
-      when /403/
-        Chef::Log.error "Possible offline Compliance Server or chef_gate auth issue."
-      when /404/
-        Chef::Log.error "Object does not exist on remote server."
-      end
-      Chef::Log.error e.message
-      raise e if run_context.node.audit.raise_if_unreachable
+      handle_http_error_code(e.response.code)
     end
   end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ description 'Allows for fetching and executing compliance profiles, and '\
 source_url 'https://github.com/chef-cookbooks/audit' if defined?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/audit/issues' if defined?(:issues_url)
 
-version '0.9.1'
+version '0.10.0'


### PR DESCRIPTION
### Description

When the token is not set correctly, the audit cookbook is returning weird errors:

```
Starting Chef Client, version 12.10.24
resolving cookbooks for run list: ["audit"]
Synchronizing Cookbooks:
  - audit (0.9.1)
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 2 resources
Recipe: audit::default
  * compliance_profile[linux] action fetch
    * chef_gem[inspec] action install
      - install version 0.22.1 of package inspec
[2016-06-01T13:06:49-07:00] WARN: Using inspec version: (0.22.1)
    - install/update inspec
    * directory[/var/chef/cache/compliance] action create
      - create new directory /var/chef/cache/compliance
    - create cache directory
    - fetch compliance profile
    * chef_gem[inspec] action install (up to date)
    * directory[/var/chef/cache/compliance] action create (up to date)

  * compliance_profile[linux] action execute
    * chef_gem[inspec] action install (up to date)
[2016-06-01T13:06:49-07:00] WARN: Using inspec version: (0.22.1)
    - install/update inspec
    * directory[/var/chef/cache/compliance] action create (up to date)
    - create/verify cache directory
    ================================================================================
    Error executing action `execute` on resource 'compliance_profile[linux]'
    ================================================================================

    Zlib::GzipFile::Error
    ---------------------
    not in gzip format

    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/audit/libraries/profile.rb:143:in `block (2 levels) in <class:ComplianceProfile>'
    /var/chef/cache/cookbooks/audit/libraries/profile.rb:126:in `block in <class:ComplianceProfile>'

    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/audit/recipes/default.rb

     38:   compliance_profile p do
     39:     owner o
     40:     server server
     41:     token token
     42:     path path unless path.nil?
     43:     inspec_version node['audit']['inspec_version']
     44:     quiet node['audit']['quiet'] unless node['audit']['quiet'].nil?
     45:     action [:fetch, :execute]
     46:   end
     47: end

    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/audit/recipes/default.rb:38:in `block in from_file'

    compliance_profile("linux") do
      action [:fetch, :execute]
      updated true
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      declared_type :compliance_profile
      cookbook_name "audit"
      recipe_name "default"
      owner "base"
      server "https://n7-z01-0a2a183b.iaas.starwave.com/api/"
      token "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFpZlhid0FaYWV6dHJCdGx2UG5JRHRZSGNqeFhjMjFuR1p3UTZsM0t6NldyZnBlN0RVM3N2OGFkRGVfN25rb0FOemwyUGktTVE0bERQSk54NkNXRkN4U2VKUWNwSHdNT1RSc0lBYzJrbTJob19Pc05zeXBZeDZSdjltcW54SnNvclVuZ2gtMVh6VFcyYTdXX1Z1ai0yUGJWM2RMWXduQ0dUS0wxOTJ5ZUp4eVFXbWdKR3hZUUdDMUpRU0VGQmlZZlhzN3hkYmtleUQ2MmhGYVN1aUYtWTdIWFhCN01wQkowemNQdEdOQW84NXdUeUhDMHJMa0FsUGxtckw5YTVZdVlSUnJ0MzNJQU5rWV9ITHNQeHdXbE9HQkRtTkd6R1R0VXJnWHNpWUh0V1J0eXZ4enJqZVFJMjNsV256WkZaQWpLUjItLWtVNGl3Q1VtVXllN3dwV1FvUT09IiwidHlwIjoiSldUIn0.eyJhdWQiOiJRQWtHNGwzVlpaUWdpbDIxcHlZX1hWbHQwQlNRQkVZbFlkckhiczJNTEU0PUBuNy16MDEtMGEyYTE4M2IuaWFhcy5zdGFyd2F2ZS5jb20iLCJjb25uZWN0b3JfaWQiOiJDb21wbGlhbmNlIFNlcnZlciIsImNvbm5lY3Rvcl9pbmZvIjoiaHR0cHM6Ly9uNy16MDEtMGEyYTE4M2IuaWFhcy5zdGFyd2F2ZS5jb20vYXBpLyIsImNvbm5lY3Rvcl90eXBlIjoiY29tcGxpYW5jZSIsImVtYWlsIjoid3VucjAwMkBjb21wbGlhbmNlLmZha2UiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiZXhwIjoxLjQ2NDc2OTU0MmUrMDksImlhdCI6MS40NjQ3MjYzNDJlKzA5LCJpc3MiOiJodHRwczovL243LXowMS0wYTJhMTgzYi5pYWFzLnN0YXJ3YXZlLmNvbSIsIm5hbWUiOiJ3dW5yMDAyIiwic3ViIjoiN2M1ZWJlZDQtN2E2NC00NGIyLWFmNmEtZWM0YTliMjg4MWUwIn0.rKueJbL4tAzTGm_ObT5XRPn9T8YjJ9u6RamRbpU4qHLnrB_4bF7ymaU7QeiqYsKrLNx1aQw-zlSFXUjo4RtHnFczWs6ZHTuYbBCMMxwN-v64aRaZ2fGX7RfkUuhkGF9yl91ory7Lk5zezvKy22tb28Hf_CYIRbHu9gmTTJXCDCNAyudZWShcP8sVFp8NjDg6iCWnRevYrv2cFX5onX7lPvnm1ExrMSruLW8iG9SRlXWu3SjFcilwXYmYhKDo0qNxp9t3YX1w4_RJwp-EdzPSbu0CHKq7g4L6bFtoAaJL_VNGI4nJD3yR3nLC5Jq2rFlMlhDhFeJ9V0msymc3xWqgTQ"
      inspec_version "0.22.1"
      profile "linux"
      quiet true
    end

    Platform:
    ---------
    x86_64-linux


Running handlers:
[2016-06-01T13:06:50-07:00] ERROR: Running exception handlers
Running handlers complete
[2016-06-01T13:06:50-07:00] ERROR: Exception handlers complete
Chef Client failed. 3 resources updated in 28 seconds
[2016-06-01T13:06:51-07:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2016-06-01T13:06:51-07:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2016-06-01T13:06:51-07:00] ERROR: compliance_profile[linux] (audit::default line 38) had an error: Zlib::GzipFile::Error: not in gzip format
[2016-06-01T13:06:51-07:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
``` 

This improvements handles non-200 response codes, that are not raised as an exception. In addition the default changes for `raise_if_unreachable` to `true`, since this means that the audit could not be executed at all.

