### PR TITLE
http_rescue not required with tempfile

### DIFF
--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -90,9 +90,7 @@ class ComplianceProfile < Chef::Resource # rubocop:disable Metrics/ClassLength
         Chef::Config[:ssl_verify_mode] = :verify_none # FIXME
 
         rest = Chef::ServerAPI.new(url, Chef::Config)
-        tf = with_http_rescue do
           rest.binmode_streaming_request(url)
-        end
       end
 
       case node['platform']

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -61,9 +61,7 @@ class ComplianceReport < Chef::Resource
         Chef::Log.info "Report to: #{url}"
 
         rest = Chef::ServerAPI.new(url, Chef::Config)
-        with_http_rescue do
           rest.post(url, blob)
-        end
       end
       fail "#{total_failed} audits have failed.  Aborting chef-client run." if total_failed > 0 && run_context.node.audit.fail_if_any_audits_failed
     end


### PR DESCRIPTION

### Issues Resolved
Throwing error at line 40 because its not a http request(when integrating with chef server). No response code.




