### PR TITLE
adding with_http_rescue method call back in

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -36,8 +36,10 @@ module ComplianceHelpers
   def with_http_rescue(&block)
     begin
       response = yield
-      # handle non 200 error codes, they are not raised as Net::HTTPServerException
-      handle_http_error_code(response.code) if response.code.to_i >= 300
+      if response.respond_to?(:code)
+        # handle non 200 error codes, they are not raised as Net::HTTPServerException
+        handle_http_error_code(response.code) if response.code.to_i >= 300
+      end
       return response
     rescue Net::HTTPServerException => e
       handle_http_error_code(e.response.code)
@@ -46,7 +48,7 @@ module ComplianceHelpers
 
   # exchanges a refresh token into an access token
   def retrieve_access_token(server, refresh_token)
-    success, msg, access_token = Compliance::API.post_refresh_token(url, refresh_token, options['insecure'])
+    _success, _msg, access_token = Compliance::API.post_refresh_token(url, refresh_token, options['insecure'])
     # TODO we return always the access token, without proper error handling
     access_token
   end

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -90,7 +90,9 @@ class ComplianceProfile < Chef::Resource # rubocop:disable Metrics/ClassLength
         Chef::Config[:ssl_verify_mode] = :verify_none # FIXME
 
         rest = Chef::ServerAPI.new(url, Chef::Config)
-        rest.binmode_streaming_request(url)
+        tf = with_http_rescue do
+          rest.binmode_streaming_request(url)
+        end
       end
 
       case node['platform']

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -61,7 +61,9 @@ class ComplianceReport < Chef::Resource
         Chef::Log.info "Report to: #{url}"
 
         rest = Chef::ServerAPI.new(url, Chef::Config)
-        rest.post(url, blob)
+        with_http_rescue do
+          rest.post(url, blob)
+        end
       end
       fail "#{total_failed} audits have failed.  Aborting chef-client run." if total_failed > 0 && run_context.node.audit.fail_if_any_audits_failed
     end


### PR DESCRIPTION
### Description

This change resolves the following error from version 0.10.0 of the cookbook:
```
 NoMethodError
    -------------
    undefined method `code' for #<Tempfile:/tmp/compliance-profile20160609-2220-117sw6.tgz>

    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/audit/libraries/helper.rb:40:in `with_http_rescue'
    /var/chef/cache/cookbooks/audit/libraries/profile.rb:93:in `block (2 levels) in <class:ComplianceProfile>'
    /var/chef/cache/cookbooks/audit/libraries/profile.rb:54:in `block in <class:ComplianceProfile>'
```

It also re-adds the `with_http_rescue` method call for proper error handling when communicating with chef_gate on the Chef Server.  It's very beneficial to have this error handling.

The `with_http_rescue` method was removed in between version 0.10.0 and 0.11.0 of the cookbook.

This change has been tested on both Linux Ubuntu 14.04 and Windows 2012R2.

### Issues Resolved

Adds back in error handling for the code path that fetches profiles through the Chef Server.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

