### PR TITLE
Standardized node access to classic way

### DIFF
--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -65,7 +65,7 @@ class ComplianceReport < Chef::Resource
           rest.post(url, blob)
         end
       end
-      fail "#{total_failed} audits have failed.  Aborting chef-client run." if total_failed > 0 && run_context.node.audit.fail_if_any_audits_failed
+      fail "#{total_failed} audits have failed.  Aborting chef-client run." if total_failed > 0 && node['audit']['fail_if_any_audits_failed']
     end
   end
 


### PR DESCRIPTION
### Description

This fixes a bug I was having where the code was using a non-standard way of accessing node attributes. Once I changed it back I no longer got the error.

### Issues Resolved

I didn't fill out this as an issue, just fixed it.

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


