### PR TITLE
removing requirement for setting chef server url

### DIFF
--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -51,11 +51,12 @@ class ComplianceReport < Chef::Resource
           Chef::Log.warn "'server' and 'token' properties required by inspec report collector '#{collector}'. Skipping..."
         end
       when 'chef-server'
-        if server
-          url = construct_url(server + '/compliance/', ::File.join('organizations', o, 'inspec'))
+        chef_url = server || base_chef_server_url
+        if chef_url
+          url = construct_url(chef_url + '/compliance/', ::File.join('organizations', o, 'inspec'))
           Collector::ChefServer.new(url, blob).send_report
         else
-          Chef::Log.warn "'server' property required by inspec report collector '#{collector}'. Skipping..."
+          Chef::Log.warn "unable to determine chef-server url required by inspec report collector '#{collector}'. Skipping..."
         end
       else
         Chef::Log.warn "#{collector} is not a supported inspec report collector"


### PR DESCRIPTION
### Description
This change removes the requirement for setting the `['audit']['server']` attribute when collector is set to `chef-server`.  If `server` is not set, then the Chef Server url will be determined by what's in the `client.rb` file.  This allows for an easier Global Chef architecture where there are regional Chef Servers - the audit cookbook can just pick up the server url from it’s client config without having to take into account regional attribute overrides.

Verification via pry when `['audit']['server']` is not set:
```
  * compliance_report[chef-server] action execute[2016-08-04T16:12:02+00:00] INFO: Summary for linux {"duration":0.621066652,"example_count":45,"failure_count":28,"skip_count":0}

Frame number: 0/36

From: /var/chef/cache/cookbooks/audit/libraries/report.rb @ line 57 ComplianceReport action provider#compile_action_execute:

    52:         end
    53:       when 'chef-server'
    54:         require 'pry'
    55:         chef_url = server || base_chef_server_url
    56:         binding.pry
 => 57:         if chef_url
    58:           url = construct_url(chef_url + '/compliance/', ::File.join('organizations', o, 'inspec'))
    59:           Collector::ChefServer.new(url, blob).send_report
    60:         else
    61:           Chef::Log.warn "unable to determine chef-server url required by inspec report collector '#{collector}'. Skipping..."
    62:         end

[1] pry(#<ComplianceReport action provider>)> server
=> nil
[2] pry(#<ComplianceReport action provider>)> base_chef_server_url
=> "https://chef-server.test"
[3] pry(#<ComplianceReport action provider>)> chef_url
=> "https://chef-server.test"
[4] pry(#<ComplianceReport action provider>)>
[2016-08-04T16:12:36+00:00] INFO: Report to: https://chef-server.test/compliance/organizations/brewinc/inspec

    - report compliance profiles' results
[2016-08-04T16:12:36+00:00] INFO: Chef Run complete in 35.786930955 seconds

Running handlers:
[2016-08-04T16:12:36+00:00] INFO: Running report handlers
Running handlers complete
[2016-08-04T16:12:36+00:00] INFO: Report handlers complete
Chef Client finished, 6/16 resources updated in 37 seconds
```

### Issues Resolved

No issues attached to this.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

