### PR TITLE
Update changelog generator task to be native rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   Exclude:
   - Gemfile
   - Rakefile
+  - 'tasks/**/*'
   - 'test/**/*'
   - 'spec/**/*'
   - 'vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
-## [0.14.0](https://github.com/chef-cookbooks/audit/tree/0.14.0) (2016-08-12)
-[Full Changelog](https://github.com/chef-cookbooks/audit/compare/v0.13.1...0.14.0)
+## [v0.14.0](https://github.com/chef-cookbooks/audit/tree/v0.14.0) (2016-08-12)
+[Full Changelog](https://github.com/chef-cookbooks/audit/compare/v0.13.1...v0.14.0)
 
 **Merged pull requests:**
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
 #!/usr/bin/env rake
 
+# Import other external rake tasks
+Dir.glob('tasks/*.rake').each { |r| import r }
+
 require 'foodcritic'
 require 'rake/clean'
 require 'rspec/core/rake_task'
@@ -42,47 +45,4 @@ namespace :test do
     path = File.join(File.dirname(__FILE__), 'test', 'integration')
     sh('sh', '-c', "bundle exec kitchen test -c #{concurrency}")
   end
-end
-
-# Check if a command is available
-#
-# @param [Type] x the command you are interested in
-# @param [Type] msg the message to display if the command is missing
-def require_command(x, msg = nil)
-  return if system("command -v #{x} || exit 1")
-  msg ||= 'Please install it first!'
-  puts "\033[31;1mCan't find command #{x.inspect}. #{msg}\033[0m"
-  exit 1
-end
-
-# Check if a required environment variable has been set
-#
-# @param [String] x the variable you are interested in
-# @param [String] msg the message you want to display if the variable is missing
-def require_env(x, msg = nil)
-  exists = `env | grep "^#{x}="`
-  return unless exists.empty?
-  puts "\033[31;1mCan't find environment variable #{x.inspect}. #{msg}\033[0m"
-  exit 1
-end
-
-# Check the requirements for running an update of this repository.
-def check_update_requirements
-  require_command 'git'
-  require_command 'github_changelog_generator', "\n"\
-    "For more information on how to install it see:\n"\
-    "  https://github.com/skywinder/github-changelog-generator\n"
-  require_env 'CHANGELOG_GITHUB_TOKEN', "\n"\
-    "Please configure this token to make sure you can run all commands\n"\
-    "against GitHub.\n\n"\
-    "See github_changelog_generator homepage for more information:\n"\
-    "  https://github.com/skywinder/github-changelog-generator\n"
-end
-
-desc 'Generate the changelog'
-task :changelog, [:version] do |_, args|
-  v = args[:version] || ENV['to']
-  fail "You must specify a target version!  rake changelog to=1.2.3" if v.empty?
-  check_update_requirements
-  system "github_changelog_generator -u chef-cookbooks -p audit --future-release #{v}"
 end

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,0 +1,51 @@
+# Check the requirements for running an update of this repository.
+task :check_update_dependencies do
+  require_command 'git'
+  require_command 'github_changelog_generator', "\n"\
+    "For more information on how to install it see:\n"\
+    "  https://github.com/skywinder/github-changelog-generator\n"
+  require_env 'CHANGELOG_GITHUB_TOKEN', "\n"\
+    "Please configure this token to make sure you can run all commands\n"\
+    "against GitHub.\n\n"\
+    "See github_changelog_generator homepage for more information:\n"\
+    "  https://github.com/skywinder/github-changelog-generator\n"
+end
+
+# Check if a command is available
+#
+# @param [Type] x the command you are interested in
+# @param [Type] msg the message to display if the command is missing
+def require_command(x, msg = nil)
+  return if system("command -v #{x} || exit 1")
+  msg ||= 'Please install it first!'
+  puts "\033[31;1mCan't find command #{x.inspect}. #{msg}\033[0m"
+  exit 1
+end
+
+# Check if a required environment variable has been set
+#
+# @param [String] x the variable you are interested in
+# @param [String] msg the message you want to display if the variable is missing
+def require_env(x, msg = nil)
+  exists = `env | grep "^#{x}="`
+  return unless exists.empty?
+  puts "\033[31;1mCan't find environment variable #{x.inspect}. #{msg}\033[0m"
+  exit 1
+end
+
+begin
+  require 'chef/cookbook/metadata'
+  require 'github_changelog_generator/task'
+
+  metadata = Chef::Cookbook::Metadata.new
+  metadata.from_file('metadata.rb')
+
+  GitHubChangelogGenerator::RakeTask.new changelog: ['check_update_dependencies'] do |config|
+    # Just have to add a v here because its the convention stove uses
+    config.future_release = "v#{metadata.version}"
+    config.user = 'chef-cookbooks'
+    config.project = 'audit'
+  end
+rescue LoadError
+  puts 'Problem loading gems please install chef and github_changelog_generator'
+end


### PR DESCRIPTION
### Description

This updates the rake task for generating the CHANGELOG documentation so that it includes the new link as well as dynamically gets the current version number.

### Issues Resolved

It solves an issue where the changelog `Full Changelog` link is generated wrong.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD