### PR TITLE
ChefCompliance collector fix

### DIFF
--- a/libraries/collector_classes.rb
+++ b/libraries/collector_classes.rb
@@ -233,7 +233,7 @@ class Collector
 
     def send_report
       req = Net::HTTP::Post.new(@url, { 'Authorization' => "Bearer #{@token}" })
-      req.body = blob.to_json
+      req.body = @blob.to_json
       Chef::Log.info "Report to: #{@url}"
 
       opts = { use_ssl: @url.scheme == 'https',

--- a/libraries/collector_classes.rb
+++ b/libraries/collector_classes.rb
@@ -225,10 +225,11 @@ class Collector
     @url = nil
     @blob = nil
 
-    def initialize(url, blob, token)
+    def initialize(url, blob, token, raise_if_unreachable)
       @url = url
       @blob = blob
       @token = token
+      @raise_if_unreachable = raise_if_unreachable
     end
 
     def send_report

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -30,7 +30,7 @@ module ComplianceHelpers
     end
     msg = 'Could not fetch the profile. Verify the authentication (e.g. token) is set properly'
     Chef::Log.error msg
-    fail msg if run_context.node.audit.raise_if_unreachable
+    fail msg if @raise_if_unreachable
   end
 
   #rubocop:disable all

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -39,6 +39,7 @@ class ComplianceReport < Chef::Resource
       # retrieve access token if a refresh token is set
       access_token = token
       access_token = retrieve_access_token unless refresh_token.nil?
+      raise_if_unreachable = run_context.node.audit.raise_if_unreachable if run_context.node.audit
 
       case collector
       when 'chef-visibility'
@@ -46,7 +47,7 @@ class ComplianceReport < Chef::Resource
       when 'chef-compliance'
         if access_token && server
           url = construct_url(server, ::File.join('/owners', o, 'inspec'))
-          Collector::ChefCompliance.new(url, blob, token).send_report
+          Collector::ChefCompliance.new(url, blob, token, raise_if_unreachable).send_report
         else
           Chef::Log.warn "'server' and 'token' properties required by inspec report collector '#{collector}'. Skipping..."
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ description 'Allows for fetching and executing compliance profiles, and '\
 source_url 'https://github.com/chef-cookbooks/audit' if defined?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/audit/issues' if defined?(:issues_url)
 
-version '0.14.0'
+version '0.14.1'


### PR DESCRIPTION
Fixes the following two exceptions when using the ChefCompliance collector:
```
           ================================================================================
           Error executing action `execute` on resource 'compliance_report[chef-server]'
           ================================================================================

           NameError
           ---------
           undefined local variable or method `blob' for #<Collector::ChefCompliance:0x00000005fbf040>

           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/audit/libraries/collector_classes.rb:236:in `send_report'
           /tmp/kitchen/cache/cookbooks/audit/libraries/report.rb:49:in `block (2 levels) in <class:ComplianceReport>'
           /tmp/kitchen/cache/cookbooks/audit/libraries/report.rb:24:in `block in <class:ComplianceReport>'
```

and:

```           ================================================================================
           Error executing action `execute` on resource 'compliance_report[chef-server]'
           ================================================================================

           NameError
           ---------
           undefined local variable or method `run_context' for #<Collector::ChefCompliance:0x00000006826440>

           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/audit/libraries/helper.rb:33:in `handle_http_error_code'
           /tmp/kitchen/cache/cookbooks/audit/libraries/helper.rb:42:in `with_http_rescue'
           /tmp/kitchen/cache/cookbooks/audit/libraries/collector_classes.rb:243:in `block in send_report'
           /tmp/kitchen/cache/cookbooks/audit/libraries/collector_classes.rb:242:in `send_report'
           /tmp/kitchen/cache/cookbooks/audit/libraries/report.rb:49:in `block (2 levels) in <class:ComplianceReport>'
           /tmp/kitchen/cache/cookbooks/audit/libraries/report.rb:24:in `block in <class:ComplianceReport>'
           /tmp/kitchen/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/runner.rb:41:in `run_action'
```