### PR TITLE
improve compliance refresh token handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ end
 
 group :test do
   gem 'rake', '~> 10'
+  gem 'berkshelf', '~> 3.3.0'
   gem 'chefspec',  '~> 4.3.0'
   gem 'coveralls', '~> 0.8.2', require: false
 end
 
 group :integration do
-  gem 'berkshelf', '~> 3.3.0'
   gem 'test-kitchen', '~> 1.6'
   gem 'kitchen-dokken'
   gem 'kitchen-inspec', '~> 0.9'

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ end
 
 desc 'Run all style checks'
 task style: ['style:chef', 'style:ruby']
+task lint: ['style']
 
 # ChefSpec
 begin

--- a/examples/kitchen/.kitchen.linux.yml
+++ b/examples/kitchen/.kitchen.linux.yml
@@ -27,6 +27,10 @@ suites:
         refresh_token:  <%= ENV['COMPLIANCE_REFRESHTOKEN'] %>
         insecure: true
         owner: admin
+        # fail converge if downloaded profile is not present
+        fail_if_not_present: true
+        # fail converge after posting report if any audits have failed
+        fail_if_any_audits_failed: false
         profiles:
           base/linux: true
           brewinc/ssh-hardening:

--- a/examples/kitchen/.kitchen.win.yml
+++ b/examples/kitchen/.kitchen.win.yml
@@ -39,5 +39,9 @@ suites:
         refresh_token:  <%= ENV['COMPLIANCE_REFRESHTOKEN'] %>
         insecure: true
         owner: admin
+        # fail converge if downloaded profile is not present
+        fail_if_not_present: true
+        # fail converge after posting report if any audits have failed
+        fail_if_any_audits_failed: false
         profiles:
           base/windows: true

--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+# exchanges a refresh token into an access token
+def retrieve_access_token(server_url, refresh_token, insecure)
+  require 'inspec'
+  require 'bundles/inspec-compliance/api'
+  require 'bundles/inspec-compliance/http'
+  _success, _msg, access_token = Compliance::API.post_refresh_token(server_url, refresh_token, insecure)
+  # TODO: we return always the access token, without proper error handling
+  access_token
+end

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -45,15 +45,9 @@ module ComplianceHelpers
       end
       return response
     rescue Net::HTTPServerException => e
+      Chef::Log.error e
       handle_http_error_code(e.response.code)
     end
-  end
-
-  # exchanges a refresh token into an access token
-  def retrieve_access_token(server_url, refresh_token, insecure)
-    _success, _msg, access_token = Compliance::API.post_refresh_token(server_url, refresh_token, insecure)
-    # TODO we return always the access token, without proper error handling
-    return access_token
   end
 
   # Returns the uuid for the current converge

--- a/libraries/inspec.rb
+++ b/libraries/inspec.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+class Audit
+  class Resource
+    class ChefInspec < Chef::Resource
+      resource_name :inspec
+
+      property :version, String, default: 'latest'
+
+      default_action :install
+
+      # installs inspec if required
+      action :install do
+        converge_by 'install/update inspec' do
+          chef_gem 'inspec' do
+            version new_resource.version if new_resource.version != 'latest'
+            compile_time true
+            action :install
+          end
+        end
+
+        converge_by 'verifies the inspec version' do
+          verify_inspec_version version
+        end
+      end
+
+      def verify_inspec_version(inspec_version)
+        require 'inspec'
+        # check we have the right inspec version
+        if Inspec::VERSION != inspec_version && inspec_version !='latest'
+          Chef::Log.warn "Wrong version of inspec (#{Inspec::VERSION}), please "\
+            'remove old versions (/opt/chef/embedded/bin/gem uninstall inspec).'
+        else
+          Chef::Log.warn "Using inspec version: (#{Inspec::VERSION})"
+        end
+      end
+    end
+  end
+end

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -6,200 +6,176 @@ require 'fileutils'
 
 # `compliance_profile` custom resource to collect and run Chef Compliance
 # profiles
-class ComplianceProfile < Chef::Resource
-  include ComplianceHelpers
-  use_automatic_resource_name
+class Audit
+  class Resource
+    class ComplianceProfile < Chef::Resource
+      include ComplianceHelpers
+      use_automatic_resource_name
 
-  property :profile, String, name_property: true
-  property :owner, String, required: true
+      property :profile, String, name_property: true
+      property :owner, String, required: true
 
-  # to use a chef-compliance server that is used with chef-server integration
-  property :server, [String, URI, nil]
-  property :port, Integer
-  property :token, [String, nil]
-  property :refresh_token, [String, nil]
-  property :insecure, [TrueClass, FalseClass], default: false
-  property :inspec_version, String, default: 'latest'
-  property :formatter, ['json', 'json-min'], default: 'json-min'
-  property :quiet, [TrueClass, FalseClass], default: true
-  # TODO(sr) it might be nice to default to settings from attributes
+      # to use a chef-compliance server that is used with chef-server integration
+      property :server, [String, URI, nil]
+      property :port, Integer
+      property :token, [String, nil]
+      property :insecure, [TrueClass, FalseClass], default: false
+      property :formatter, ['json', 'json-min'], default: 'json-min'
+      property :quiet, [TrueClass, FalseClass], default: true
+      # TODO(sr) it might be nice to default to settings from attributes
 
-  # alternative to (owner, profile)-addressing for profiles,
-  # e.g. for running profiles from disk (coming from some other source)
-  property :path, String
+      # alternative to (owner, profile)-addressing for profiles,
+      # e.g. for running profiles from disk (coming from some other source)
+      property :path, String
 
-  default_action :execute
+      default_action :execute
 
-  action :fetch do
-    converge_by 'install/update inspec' do
-      chef_gem 'inspec' do
-        version inspec_version if inspec_version != 'latest'
-        compile_time true
-        action :install
-      end
+      action :fetch do
+        converge_by 'load required inspec modules' do
+          require 'inspec'
+          # load the supermarket plugin
+          require 'bundles/inspec-supermarket/api'
+          require 'bundles/inspec-supermarket/target'
 
-      require 'inspec'
-      # load the supermarket plugin
-      require 'bundles/inspec-supermarket/api'
-      require 'bundles/inspec-supermarket/target'
+          # load the compliance api plugin
+          require 'bundles/inspec-compliance/api'
+          require 'bundles/inspec-compliance/http'
+        end
 
-      # load the compliance api plugin
-      require 'bundles/inspec-compliance/api'
-      require 'bundles/inspec-compliance/http'
+        converge_by 'create cache directory' do
+          directory(::File.join(Chef::Config[:file_cache_path], 'compliance')).run_action(:create)
+        end
 
-      check_inspec
-    end
+        converge_by 'fetch compliance profile' do
+          return if path # will be fetched from other source during execute phase
 
-    converge_by 'create cache directory' do
-      directory(::File.join(Chef::Config[:file_cache_path], 'compliance')).run_action(:create)
-    end
+          o, p = normalize_owner_profile
+          Chef::Log.info "Fetch compliance profile #{o}/#{p}"
 
-    converge_by 'fetch compliance profile' do
-      return if path # will be fetched from other source during execute phase
+          path = tar_path
+          access_token = token
 
-      o, p = normalize_owner_profile
-      Chef::Log.info "Fetch compliance profile #{o}/#{p}"
+          if access_token # go direct
+            reqpath ="owners/#{o}/compliance/#{p}/tar"
+            url = construct_url(server, reqpath)
+            Chef::Log.info "Load profile from: #{url}"
 
-      path = tar_path
+            tf = Tempfile.new('foo', Dir.tmpdir, 'wb+')
+            tf.binmode
 
-      # retrieve access token if a refresh token is set
-      access_token = token
-      access_token = retrieve_access_token(server, refresh_token, insecure) unless refresh_token.nil?
+            opts = { use_ssl: url.scheme == 'https',
+                     verify_mode: OpenSSL::SSL::VERIFY_NONE, # FIXME
+            }
+            Net::HTTP.start(url.host, url.port, opts) do |http|
+              resp = with_http_rescue do
+                http.get(url.path, 'Authorization' => "Bearer #{access_token}")
+              end
+              tf.write(resp.body)
+            end
+            tf.flush
+          else # go through Chef::ServerAPI
+            reqpath ="organizations/#{org}/owners/#{o}/compliance/#{p}/tar"
+            url = construct_url(base_chef_server_url + '/compliance/', reqpath)
+            Chef::Log.info "Load profile from: #{url}"
 
-      if access_token # go direct
-        reqpath ="owners/#{o}/compliance/#{p}/tar"
-        url = construct_url(server, reqpath)
-        Chef::Log.info "Load profile from: #{url}"
+            Chef::Config[:verify_api_cert] = false # FIXME
+            Chef::Config[:ssl_verify_mode] = :verify_none # FIXME
 
-        tf = Tempfile.new('foo', Dir.tmpdir, 'wb+')
-        tf.binmode
-
-        opts = { use_ssl: url.scheme == 'https',
-                 verify_mode: OpenSSL::SSL::VERIFY_NONE, # FIXME
-        }
-        Net::HTTP.start(url.host, url.port, opts) do |http|
-          resp = with_http_rescue do
-            http.get(url.path, 'Authorization' => "Bearer #{access_token}")
+            rest = Chef::ServerAPI.new(url, Chef::Config)
+            tf = with_http_rescue do
+              rest.binmode_streaming_request(url)
+            end
           end
-          tf.write(resp.body)
-        end
-        tf.flush
-      else # go through Chef::ServerAPI
-        reqpath ="organizations/#{org}/owners/#{o}/compliance/#{p}/tar"
-        url = construct_url(base_chef_server_url + '/compliance/', reqpath)
-        Chef::Log.info "Load profile from: #{url}"
 
-        Chef::Config[:verify_api_cert] = false # FIXME
-        Chef::Config[:ssl_verify_mode] = :verify_none # FIXME
+          case node['platform']
+          when 'windows'
+            # mv replaced due to Errno::EACCES:
+            # https://bugs.ruby-lang.org/issues/10865
+            FileUtils.cp(tf.path, path) unless tf.nil?
+          else
+            FileUtils.mv(tf.path, path) unless tf.nil?
+          end
 
-        rest = Chef::ServerAPI.new(url, Chef::Config)
-        tf = with_http_rescue do
-          rest.binmode_streaming_request(url)
         end
       end
 
-      case node['platform']
-      when 'windows'
-        # mv replaced due to Errno::EACCES:
-        # https://bugs.ruby-lang.org/issues/10865
-        FileUtils.cp(tf.path, path) unless tf.nil?
-      else
-        FileUtils.mv(tf.path, path) unless tf.nil?
+      action :execute do
+        # ensure it's there, if if the profile wasn't fetched using these resources
+        converge_by 'load required inspec modules' do
+          require 'inspec'
+        end
+
+        converge_by 'create/verify cache directory' do
+          directory(::File.join(Chef::Config[:file_cache_path], 'compliance')).run_action(:create)
+        end
+
+        converge_by 'execute compliance profile' do
+          path ||= tar_path
+          report_file = report_path
+
+          supported_schemes = %w{http https supermarket compliance chefserver}
+          if !supported_schemes.include?(URI(path).scheme) && !::File.exist?(path)
+            Chef::Log.warn "No such path! Skipping: #{path}"
+            raise "Aborting since profile is not present here: #{path}" if run_context.node['audit']['fail_if_not_present']
+            return
+          end
+
+          Chef::Log.info "Executing: #{path}"
+
+          # TODO: flesh out inspec's report CLI interface,
+          #       make this an execute[inspec check ...]
+          output = quiet ? ::File::NULL : $stdout
+          runner = ::Inspec::Runner.new('report' => true, 'format' => formatter, 'output' => output)
+          runner.add_target(path, {})
+          begin
+            runner.run
+          # TODO: weird exception, do we need that handling?
+          rescue Chef::Exceptions::ValidationFailed => e
+            Chef::Log.error e
+          end
+
+          file report_file do
+            content runner.report.to_json
+            sensitive true
+            backup false
+          end
+        end
       end
 
-    end
-  end
-
-  action :execute do
-    # ensure it's there, if if the profile wasn't fetched using these resources
-    converge_by 'install/update inspec' do
-      chef_gem 'inspec' do
-        version inspec_version if inspec_version != 'latest'
-        compile_time true
+      def normalize_owner_profile
+        if profile.include?('/')
+          profile.split('/').last(2)
+        else
+          [owner || 'base', profile]
+        end
       end
 
-      require 'inspec'
-      check_inspec
-    end
-
-    converge_by 'create/verify cache directory' do
-      directory(::File.join(Chef::Config[:file_cache_path], 'compliance')).run_action(:create)
-    end
-
-    converge_by 'execute compliance profile' do
-      path ||= tar_path
-      report_file = report_path
-
-      supported_schemes = %w{http https supermarket compliance chefserver}
-      if !supported_schemes.include?(URI(path).scheme) && !::File.exist?(path)
-        Chef::Log.warn "No such path! Skipping: #{path}"
-        raise "Aborting since profile is not present here: #{path}" if run_context.node['audit']['fail_if_not_present']
-        return
+      def tar_path
+        return path if path
+        o, p = normalize_owner_profile
+        case node['platform']
+        when 'windows'
+          windows_path = Chef::Config[:file_cache_path].tr('\\', '/')
+          ::File.join(windows_path, 'compliance', "#{o}_#{p}.tgz")
+        else
+          ::File.join(Chef::Config[:file_cache_path], 'compliance', "#{o}_#{p}.tgz")
+        end
       end
 
-      Chef::Log.info "Executing: #{path}"
-
-      # TODO: flesh out inspec's report CLI interface,
-      #       make this an execute[inspec check ...]
-      output = quiet ? ::File::NULL : $stdout
-      runner = ::Inspec::Runner.new('report' => true, 'format' => formatter, 'output' => output)
-      runner.add_target(path, {})
-      begin
-        runner.run
-      # TODO: weird exception, do we need that handling?
-      rescue Chef::Exceptions::ValidationFailed => e
-        log "INSPEC #{e}"
+      def report_path
+        o, p = normalize_owner_profile
+        case node['platform']
+        when 'windows'
+          windows_path = Chef::Config[:file_cache_path].tr('\\', '/')
+          ::File.join(windows_path, 'compliance', "#{o}_#{p}_report.json")
+        else
+          ::File.join(Chef::Config[:file_cache_path], 'compliance', "#{o}_#{p}_report.json")
+        end
       end
 
-      file report_file do
-        content runner.report.to_json
-        sensitive true
-        backup false
+      def org
+        Chef::Config[:chef_server_url].split('/').last
       end
     end
-  end
-
-  def check_inspec
-    if Inspec::VERSION != inspec_version && inspec_version !='latest'
-      Chef::Log.warn "Wrong version of inspec (#{Inspec::VERSION}), please "\
-        'remove old versions (/opt/chef/embedded/bin/gem uninstall inspec).'
-    else
-      Chef::Log.warn "Using inspec version: (#{Inspec::VERSION})"
-    end
-  end
-
-  def normalize_owner_profile
-    if profile.include?('/')
-      profile.split('/').last(2)
-    else
-      [owner || 'base', profile]
-    end
-  end
-
-  def tar_path
-    return path if path
-    o, p = normalize_owner_profile
-    case node['platform']
-    when 'windows'
-      windows_path = Chef::Config[:file_cache_path].tr('\\', '/')
-      ::File.join(windows_path, 'compliance', "#{o}_#{p}.tgz")
-    else
-      ::File.join(Chef::Config[:file_cache_path], 'compliance', "#{o}_#{p}.tgz")
-    end
-  end
-
-  def report_path
-    o, p = normalize_owner_profile
-    case node['platform']
-    when 'windows'
-      windows_path = Chef::Config[:file_cache_path].tr('\\', '/')
-      ::File.join(windows_path, 'compliance', "#{o}_#{p}_report.json")
-    else
-      ::File.join(Chef::Config[:file_cache_path], 'compliance', "#{o}_#{p}_report.json")
-    end
-  end
-
-  def org
-    Chef::Config[:chef_server_url].split('/').last
   end
 end

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -1,108 +1,110 @@
 # encoding: utf-8
 # `compliance_report` custom resource to run Chef Compliance profiles and
 # send reports to Chef Compliance
-class ComplianceReport < Chef::Resource
-  include ComplianceHelpers
-  use_automatic_resource_name
+class Audit
+  class Resource
+    class ComplianceReport < Chef::Resource
+      include ComplianceHelpers
+      use_automatic_resource_name
 
-  property :name, String, name_property: true
+      property :name, String, name_property: true
 
-  # to use a chef-compliance server that is used with chef-server integration
-  property :server, [String, URI, nil]
-  property :port, Integer
-  property :token, [String, nil]
-  property :refresh_token, [String, nil]
-  property :insecure, [TrueClass, FalseClass], default: false
-  property :quiet, [TrueClass, FalseClass], default: true
-  property :collector, ['chef-visibility', 'chef-compliance', 'chef-server'], default: 'chef-server'
+      # to use a chef-compliance server that is used with chef-server integration
+      property :server, [String, URI, nil]
+      property :port, Integer
+      property :token, [String, nil]
+      property :insecure, [TrueClass, FalseClass], default: false
+      property :quiet, [TrueClass, FalseClass], default: true
+      property :collector, ['chef-visibility', 'chef-compliance', 'chef-server'], default: 'chef-server'
 
-  property :environment, String # default: node.environment
-  property :owner, [String, nil]
+      property :environment, String # default: node.environment
+      property :owner, [String, nil]
 
-  default_action :execute
+      default_action :execute
 
-  action :execute do
-    converge_by "report compliance profiles' results" do
-      reports, ownermap = compound_report(profiles)
+      action :execute do
+        converge_by "report compliance profiles' results" do
+          reports, ownermap = compound_report(profiles)
 
-      blob = node_info
-      blob[:reports] = reports
-      total_failed = 0
-      blob[:reports].each do |k, _|
-        Chef::Log.info "Summary for #{k} #{blob[:reports][k]['summary'].to_json}" if quiet
-        total_failed += blob[:reports][k]['summary']['failure_count'].to_i
-      end
-      blob[:profiles] = ownermap
+          blob = node_info
+          blob[:reports] = reports
+          total_failed = 0
+          blob[:reports].each do |k, _|
+            Chef::Log.info "Summary for #{k} #{blob[:reports][k]['summary'].to_json}" if quiet
+            total_failed += blob[:reports][k]['summary']['failure_count'].to_i
+          end
+          blob[:profiles] = ownermap
 
-      # resolve owner
-      o = return_or_guess_owner
+          # resolve owner
+          o = return_or_guess_owner
 
-      # retrieve access token if a refresh token is set
-      access_token = token
-      raise_if_unreachable = run_context.node.audit.raise_if_unreachable if run_context.node.audit
+          # retrieve access token if a refresh token is set
+          access_token = token
+          raise_if_unreachable = run_context.node.audit.raise_if_unreachable if run_context.node.audit
 
-      case collector
-      when 'chef-visibility'
-        Collector::ChefVisibility.new(entity_uuid, run_id, blob).send_report
-      when 'chef-compliance'
-        access_token = retrieve_access_token(server, refresh_token, insecure) unless refresh_token.nil?
-        if access_token && server
-          url = construct_url(server, ::File.join('/owners', o, 'inspec'))
-          Collector::ChefCompliance.new(url, blob, token, raise_if_unreachable).send_report
-        else
-          Chef::Log.warn "'server' and 'token' properties required by inspec report collector '#{collector}'. Skipping..."
+          case collector
+          when 'chef-visibility'
+            Collector::ChefVisibility.new(entity_uuid, run_id, blob).send_report
+          when 'chef-compliance'
+            if access_token && server
+              url = construct_url(server, ::File.join('/owners', o, 'inspec'))
+              Collector::ChefCompliance.new(url, blob, token, raise_if_unreachable).send_report
+            else
+              Chef::Log.warn "'server' and 'token' properties required by inspec report collector '#{collector}'. Skipping..."
+            end
+          when 'chef-server'
+            chef_url = server || base_chef_server_url
+            if chef_url
+              url = construct_url(chef_url + '/compliance/', ::File.join('organizations', o, 'inspec'))
+              Collector::ChefServer.new(url, blob).send_report
+            else
+              Chef::Log.warn "unable to determine chef-server url required by inspec report collector '#{collector}'. Skipping..."
+            end
+          else
+            Chef::Log.warn "#{collector} is not a supported inspec report collector"
+          end
+
+          raise "#{total_failed} audits have failed.  Aborting chef-client run." if total_failed > 0 && node['audit']['fail_if_any_audits_failed']
         end
-      when 'chef-server'
-        chef_url = server || base_chef_server_url
-        if chef_url
-          url = construct_url(chef_url + '/compliance/', ::File.join('organizations', o, 'inspec'))
-          Collector::ChefServer.new(url, blob).send_report
-        else
-          Chef::Log.warn "unable to determine chef-server url required by inspec report collector '#{collector}'. Skipping..."
-        end
-      else
-        Chef::Log.warn "#{collector} is not a supported inspec report collector"
       end
 
-      raise "#{total_failed} audits have failed.  Aborting chef-client run." if total_failed > 0 && node['audit']['fail_if_any_audits_failed']
+      # filters resource collection
+      def profiles
+        run_context.resource_collection.select do |r|
+          r.is_a?(ComplianceProfile)
+        end.flatten
+      end
+
+      def compound_report(*profiles)
+        report = {}
+        ownermap = {}
+
+        profiles.flatten.each do |prof|
+          next unless ::File.exist?(prof.report_path)
+          o, p = prof.normalize_owner_profile
+          report[p] = ::JSON.parse(::File.read(prof.report_path))
+          ownermap[p] = o
+        end
+
+        [report, ownermap]
+      end
+
+      def node_info
+        n = run_context.node
+        {
+          node: n.name,
+          os: {
+            # arch: os[:arch],
+            release: n['platform_version'],
+            family: n['platform'],
+          },
+          environment: environment || n.environment,
+        }
+      end
+
+      def return_or_guess_owner
+        owner || Chef::Config[:chef_server_url].split('/').last
+      end
     end
-  end
-
-  # filters resource collection
-  def profiles
-    run_context.resource_collection.select do |r|
-      r.is_a?(ComplianceProfile)
-    end.flatten
-  end
-
-  def compound_report(*profiles)
-    report = {}
-    ownermap = {}
-
-    profiles.flatten.each do |prof|
-      next unless ::File.exist?(prof.report_path)
-      o, p = prof.normalize_owner_profile
-      report[p] = ::JSON.parse(::File.read(prof.report_path))
-      ownermap[p] = o
-    end
-
-    [report, ownermap]
-  end
-
-  def node_info
-    n = run_context.node
-    {
-      node: n.name,
-      os: {
-        # arch: os[:arch],
-        release: n['platform_version'],
-        family: n['platform'],
-      },
-      environment: environment || n.environment,
-    }
-  end
-
-  def return_or_guess_owner
-    owner || Chef::Config[:chef_server_url].split('/').last
   end
 end

--- a/recipes/_inspec.rb
+++ b/recipes/_inspec.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+#
+# Cookbook Name:: compliance
+# Recipe:: inspec
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+inspec_version = node['audit']['inspec_version']
+
+# install inspec if require
+inspec 'inspec' do
+  version inspec_version
+  action :install
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -34,6 +34,7 @@ describe 'audit::default' do
   context 'When server and refresh_token are specified' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
+        node.set['audit']['collector'] = 'chef-compliance'
         node.set['audit']['profiles'] = { 'admin/myprofile' => true }
         node.set['audit']['server'] = 'https://my.compliance.test/api'
         node.set['audit']['refresh_token'] = 'abcdefg'
@@ -44,12 +45,10 @@ describe 'audit::default' do
     it 'fetches and executes compliance_profile[myprofile]' do
       expect(chef_run).to fetch_compliance_profile('myprofile').with(
         server: 'https://my.compliance.test/api',
-        refresh_token: 'abcdefg',
         insecure: true,
       )
       expect(chef_run).to execute_compliance_profile('myprofile').with(
         server: 'https://my.compliance.test/api',
-        refresh_token: 'abcdefg',
         insecure: true,
       )
     end
@@ -74,13 +73,11 @@ describe 'audit::default' do
         owner: 'admin',
         server: nil,
         token: nil,
-        inspec_version: 'latest',
       )
       expect(chef_run).to execute_compliance_profile('myprofile').with(
         owner: 'admin',
         server: nil,
         token: nil,
-        inspec_version: 'latest',
         quiet: true,
       )
       expect(chef_run).to execute_compliance_report('chef-server').with(


### PR DESCRIPTION
### Description

This PR is doing the following:
- extract inspec gem installation
- ensures the refresh token is only exchanged once

### Issues Resolved

Customers reported that `refresh_token` handling was not working as expected and lead to authentication errors for some requests.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

