### PR TITLE
fix Tempfile.new

### DIFF
--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -60,7 +60,7 @@ class Audit
             url = construct_url(server, reqpath)
             Chef::Log.info "Load profile from: #{url}"
 
-            tf = Tempfile.new('foo', Dir.tmpdir, :binmode => true)
+            tf = Tempfile.new('foo', Dir.tmpdir, binmode: true)
 
             opts = { use_ssl: url.scheme == 'https',
                      verify_mode: OpenSSL::SSL::VERIFY_NONE, # FIXME

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -60,8 +60,7 @@ class Audit
             url = construct_url(server, reqpath)
             Chef::Log.info "Load profile from: #{url}"
 
-            tf = Tempfile.new('foo', Dir.tmpdir, 'wb+')
-            tf.binmode
+            tf = Tempfile.new('foo', Dir.tmpdir, :binmode => true)
 
             opts = { use_ssl: url.scheme == 'https',
                      verify_mode: OpenSSL::SSL::VERIFY_NONE, # FIXME


### PR DESCRIPTION
### Description
This PR fixes the call to `Tempfile.new`

### Issues Resolved
Since Ruby 2.2.0 bundled in newer versions of chef-client, `Tempfile.new` errors with:

```
    ================================================================================
    Error executing action `fetch` on resource 'compliance_profile[linux]'
    ================================================================================

    ArgumentError
    -------------
    wrong number of arguments (given 3, expected 0..2)

    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/audit/libraries/profile.rb:64:in `new'
```

This is because Tempfile.new has just ignored the 'wb+' option - not so any more.

https://bugs.ruby-lang.org/issues/10690

This PR fixes how the Tempfile object is instantiated.

As documented here: http://ruby-doc.org/stdlib-2.3.1/libdoc/tempfile/rdoc/Tempfile.html#method-c-new Tempfile.new will open the file with "w+" by default; then using `bindmode=>true` we get binary mode.

```
~/Devel/ChefProject/tmp$ ruby test_fileutils.rb

Frame number: 0/1

From: /Users/jmiller/Devel/ChefProject/tmp/test_fileutils.rb @ line 5 :

    1: require 'tempfile'
    2: require 'pry'
    3: tf = Tempfile.new('foo', Dir.tmpdir, :binmode => true)
    4: binding.pry
 => 5: puts tf

[1] pry(main)> tf.binmode?
=> true
[2] pry(main)> File.writable?(tf.path)
=> true
[3] pry(main)>
```

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

