### PR TITLE
Improve logging and comments for attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,15 +19,16 @@
 # collector possible values: chef-server, chef-compliance, chef-visibility
 # chef-visibility requires inspec version 0.27.1 or above
 default['audit']['collector'] = 'chef-server'
-# server and token are only needed for the 'chef-compliance' collector
+
+# Attributes server, insecure and token/refresh_token are only needed for the 'chef-compliance' collector
+# server format example: 'https://comp-server.example.com/api'
 default['audit']['server'] = nil
-# choose between token and refresh_token
-# the token, needed for the 'chef-compliance' collector
-default['audit']['token'] = nil
-# refresh_token needed for the 'chef-compliance' collector
+# choose between refresh_token or token(access_token). Needed only for the 'chef-compliance' collector
 default['audit']['refresh_token'] = nil
-# if self-signed certificates are used
+default['audit']['token'] = nil
+# set this insecure attribute to true if the compliance server uses self-signed ssl certificates
 default['audit']['insecure'] = nil
+
 # owner needed for the 'chef-compliance' and 'chef-server' collectors
 default['audit']['owner'] = nil
 default['audit']['quiet'] = nil

--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -5,7 +5,10 @@ def retrieve_access_token(server_url, refresh_token, insecure)
   require 'inspec'
   require 'bundles/inspec-compliance/api'
   require 'bundles/inspec-compliance/http'
-  _success, _msg, access_token = Compliance::API.post_refresh_token(server_url, refresh_token, insecure)
+  success, msg, access_token = Compliance::API.post_refresh_token(server_url, refresh_token, insecure)
   # TODO: we return always the access token, without proper error handling
+  unless success
+    Chef::Log.error("Unable to get a Chef Compliance API access_token: #{msg}")
+  end
   access_token
 end


### PR DESCRIPTION
Method `retrieve_access_token` is not providing any logging if it fails to get an access token. This provides misleading error messages like:

```
 Recipe: audit::default
   * ruby_block[exchange_refresh_token] action run
     - execute the ruby block exchange_refresh_token
   * directory[/tmp/kitchen/cache/compliance] action create (up to date)
   * file[/tmp/kitchen/cache/compliance/apache] action nothing (skipped due to action :nothing)
   * compliance_profile[apache] action fetch
     - load required inspec modules
     * directory[/tmp/kitchen/cache/compliance] action create (up to date)
     - create cache directory[2016-09-05T12:42:06+00:00] ERROR: 404 "Not Found" (Net::HTTPServerException)
 /opt/chef/embedded/lib/ruby/2.1.0/net/http/response.rb:119:in `error!'
 /tmp/kitchen/cache/cookbooks/audit/libraries/server_api.rb:23:in `binmode_streaming_request'
 ```

This PR, logs the ERROR as part of the `retrieve_access_token` call.

```
 Recipe: audit::default
     * ruby_block[exchange_refresh_token] action run[2016-09-05T12:40:51+00:00] ERROR: Unable to get a Chef Compliance API access_token: 757: unexpected token at 'unable to trade refresh token for access token with issuer: invalid_request'
```