### PR TITLE
Compliance Token resource

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -5,6 +5,10 @@ if defined?(ChefSpec)
 
   ChefSpec.define_matcher :compliance_profile
 
+  def create_compliance_token(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:compliance_token, :create, resource_name)
+  end
+
   def fetch_compliance_profile(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:compliance_profile, :fetch, resource_name)
   end

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -18,6 +18,7 @@ class Audit
       # to use a chef-compliance server that is used with chef-server integration
       property :server, [String, URI, nil]
       property :port, Integer
+      property :insecure, [TrueClass, FalseClass], default: false
       property :formatter, ['json', 'json-min'], default: 'json-min'
       property :quiet, [TrueClass, FalseClass], default: true
       # TODO(sr) it might be nice to default to settings from attributes

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -18,8 +18,6 @@ class Audit
       # to use a chef-compliance server that is used with chef-server integration
       property :server, [String, URI, nil]
       property :port, Integer
-      property :token, [String, nil]
-      property :insecure, [TrueClass, FalseClass], default: false
       property :formatter, ['json', 'json-min'], default: 'json-min'
       property :quiet, [TrueClass, FalseClass], default: true
       # TODO(sr) it might be nice to default to settings from attributes
@@ -53,9 +51,9 @@ class Audit
           Chef::Log.info "Fetch compliance profile #{o}/#{p}"
 
           path = tar_path
-          access_token = token
+          node.run_state['compliance'] ||= {}
 
-          if access_token # go direct
+          if node.run_state['compliance']['access_token'] # go direct
             reqpath ="owners/#{o}/compliance/#{p}/tar"
             url = construct_url(server, reqpath)
             Chef::Log.info "Load profile from: #{url}"
@@ -67,7 +65,7 @@ class Audit
             }
             Net::HTTP.start(url.host, url.port, opts) do |http|
               resp = with_http_rescue do
-                http.get(url.path, 'Authorization' => "Bearer #{access_token}")
+                http.get(url.path, 'Authorization' => "Bearer #{node.run_state['compliance']['access_token']}")
               end
               tf.write(resp.body)
             end

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -12,8 +12,6 @@ class Audit
       # to use a chef-compliance server that is used with chef-server integration
       property :server, [String, URI, nil]
       property :port, Integer
-      property :token, [String, nil]
-      property :insecure, [TrueClass, FalseClass], default: false
       property :quiet, [TrueClass, FalseClass], default: true
       property :collector, ['chef-visibility', 'chef-compliance', 'chef-server'], default: 'chef-server'
 
@@ -38,17 +36,16 @@ class Audit
           # resolve owner
           o = return_or_guess_owner
 
-          # retrieve access token if a refresh token is set
-          access_token = token
-          raise_if_unreachable = run_context.node.audit.raise_if_unreachable if run_context.node.audit
+          raise_if_unreachable = run_context.node['audit']['raise_if_unreachable'] if run_context.node['audit']
 
           case collector
           when 'chef-visibility'
             Collector::ChefVisibility.new(entity_uuid, run_id, blob).send_report
           when 'chef-compliance'
-            if access_token && server
+            node.run_state['compliance'] ||= {}
+            if node.run_state['compliance']['access_token'] && server
               url = construct_url(server, ::File.join('/owners', o, 'inspec'))
-              Collector::ChefCompliance.new(url, blob, token, raise_if_unreachable).send_report
+              Collector::ChefCompliance.new(url, blob, node.run_state['compliance']['access_token'], raise_if_unreachable).send_report
             else
               Chef::Log.warn "'server' and 'token' properties required by inspec report collector '#{collector}'. Skipping..."
             end

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -12,6 +12,7 @@ class Audit
       # to use a chef-compliance server that is used with chef-server integration
       property :server, [String, URI, nil]
       property :port, Integer
+      property :insecure, [TrueClass, FalseClass], default: false
       property :quiet, [TrueClass, FalseClass], default: true
       property :collector, ['chef-visibility', 'chef-compliance', 'chef-server'], default: 'chef-server'
 

--- a/libraries/token.rb
+++ b/libraries/token.rb
@@ -12,10 +12,10 @@ class Audit
       property :token, [String, nil], required: true
       property :insecure, [TrueClass, FalseClass], default: false
 
-      default_action :exchange
+      default_action :create
 
-      action :exchange do
-        converge_by 'exchange compliance token if necessary' do
+      action :create do
+        converge_by 'compliance server auth token setup' do
           # stash token in node.run_state to pass between resources
           node.run_state['compliance'] ||= {}
           if node['audit']['refresh_token']

--- a/libraries/token.rb
+++ b/libraries/token.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+
+# `compliance_token` custom resource to communicate with Chef Compliance
+class Audit
+  class Resource
+    class ComplianceToken < Chef::Resource
+      include ComplianceHelpers
+      use_automatic_resource_name
+
+      property :server, [String, URI, nil], required: true
+      property :port, Integer
+      property :token, [String, nil], required: true
+      property :insecure, [TrueClass, FalseClass], default: false
+
+      default_action :exchange
+
+      action :exchange do
+        converge_by 'exchange compliance token if necessary' do
+          # stash token in node.run_state to pass between resources
+          node.run_state['compliance'] ||= {}
+          if node['audit']['refresh_token']
+            Chef::Log.info 'Using refresh_token to exchange for an access token.'
+            node.run_state['compliance']['access_token'] = retrieve_access_token(server, token, insecure)
+          else
+            Chef::Log.info 'Using token attribute. This token is short lived and will expire.'
+            node.run_state['compliance']['access_token'] = token
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -34,22 +34,28 @@ describe 'audit::default' do
   context 'When server and refresh_token are specified' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['audit']['collector'] = 'chef-compliance'
-        node.set['audit']['profiles'] = { 'admin/myprofile' => true }
-        node.set['audit']['server'] = 'https://my.compliance.test/api'
-        node.set['audit']['refresh_token'] = 'abcdefg'
-        node.set['audit']['insecure'] = true
+        node.override['audit']['collector'] = 'chef-compliance'
+        node.override['audit']['profiles'] = { 'admin/myprofile' => true }
+        node.override['audit']['server'] = 'https://my.compliance.test/api'
+        node.override['audit']['refresh_token'] = 'abcdefg'
+        node.override['audit']['insecure'] = true
       end.converge(described_recipe)
+    end
+
+    it 'creates compliance_token resource' do
+      expect(chef_run).to create_compliance_token('Compliance Token').with(
+        server: 'https://my.compliance.test/api',
+        insecure: true,
+        token: 'abcdefg'
+      )
     end
 
     it 'fetches and executes compliance_profile[myprofile]' do
       expect(chef_run).to fetch_compliance_profile('myprofile').with(
         server: 'https://my.compliance.test/api',
-        insecure: true,
       )
       expect(chef_run).to execute_compliance_profile('myprofile').with(
         server: 'https://my.compliance.test/api',
-        insecure: true,
       )
     end
 


### PR DESCRIPTION
### Description

This PR introduces `compliance_token` resource.
The goal is to have a self-contained resource for storing the Compliance Server token and exchanging the `refresh_token` for an access token, if needed.

The `compliance_token` resource stashes the token in Chef's `node.run_state` hash. The token can then be passed between resources, and evaluated during the execution phase. run_state is always discarded at the end of the chef-client run.

### Issues Resolved

N/A

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
