### PR TITLE
profile upload

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,3 +54,6 @@ default['audit']['interval']['time'] = 1440
 
 # quiet mode, on by default because this is testing, resources aren't converged in the normal chef sense
 default['audit']['quiet'] = true
+
+# overwrite existing profile in upload mode
+default['audit']['overwrite'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,7 +45,7 @@ default['audit']['fail_if_not_present'] = false
 default['audit']['fail_if_any_audits_failed'] = false
 
 # inspec gem version to install(e.g. '0.22.1') or 'latest'
-default['audit']['inspec_version'] = '0.27.1'
+default['audit']['inspec_version'] = '0.34.1'
 
 # by default run audit every time
 default['audit']['interval']['enabled'] = false

--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -5,6 +5,7 @@ def retrieve_access_token(server_url, refresh_token, insecure)
   require 'inspec'
   require 'bundles/inspec-compliance/api'
   require 'bundles/inspec-compliance/http'
+  require 'bundles/inspec-compliance/configuration'
   success, msg, access_token = Compliance::API.post_refresh_token(server_url, refresh_token, insecure)
   # TODO: we return always the access token, without proper error handling
   unless success

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -5,6 +5,10 @@ if defined?(ChefSpec)
 
   ChefSpec.define_matcher :compliance_profile
 
+  def create_compliance_token(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:compliance_token, :create, resource_name)
+  end
+
   def fetch_compliance_profile(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:compliance_profile, :fetch, resource_name)
   end

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -140,6 +140,22 @@ class Audit
         end
       end
 
+      action :upload do
+        converge_by 'upload compliance profile' do
+          fail 'unable to determine path to compressed profile archive' if path.nil?
+          o, p = normalize_owner_profile
+          node.run_state['compliance'] ||= {}
+
+          if node.run_state['compliance']['access_token']
+            reqpath ="owners/#{o}/compliance/#{p}/tar"
+            url = construct_url(server, reqpath)
+            Chef::Log.info "Upload compliance profile #{o}/#{p} to: #{url}"
+            res = Compliance::HTTP.post_file(url.to_s, node.run_state['compliance']['access_token'], path, insecure)
+            Chef::Log.info "Got: #{res.code} #{res.message}"
+          end
+        end
+      end
+
       def normalize_owner_profile
         if profile.include?('/')
           profile.split('/').last(2)

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -18,7 +18,6 @@ class Audit
       # to use a chef-compliance server that is used with chef-server integration
       property :server, [String, URI, nil]
       property :port, Integer
-      property :token, [String, nil]
       property :insecure, [TrueClass, FalseClass], default: false
       property :formatter, ['json', 'json-min'], default: 'json-min'
       property :quiet, [TrueClass, FalseClass], default: true
@@ -53,9 +52,9 @@ class Audit
           Chef::Log.info "Fetch compliance profile #{o}/#{p}"
 
           path = tar_path
-          access_token = token
+          node.run_state['compliance'] ||= {}
 
-          if access_token # go direct
+          if node.run_state['compliance']['access_token'] # go direct
             reqpath ="owners/#{o}/compliance/#{p}/tar"
             url = construct_url(server, reqpath)
             Chef::Log.info "Load profile from: #{url}"
@@ -67,7 +66,7 @@ class Audit
             }
             Net::HTTP.start(url.host, url.port, opts) do |http|
               resp = with_http_rescue do
-                http.get(url.path, 'Authorization' => "Bearer #{access_token}")
+                http.get(url.path, 'Authorization' => "Bearer #{node.run_state['compliance']['access_token']}")
               end
               tf.write(resp.body)
             end

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -142,7 +142,7 @@ class Audit
 
       action :upload do
         converge_by 'upload compliance profile' do
-          fail 'unable to determine path to compressed profile archive' if path.nil?
+          raise 'unable to determine path to compressed profile archive' if path.nil?
           o, p = normalize_owner_profile
           node.run_state['compliance'] ||= {}
 

--- a/libraries/token.rb
+++ b/libraries/token.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+
+# `compliance_token` custom resource to communicate with Chef Compliance
+class Audit
+  class Resource
+    class ComplianceToken < Chef::Resource
+      include ComplianceHelpers
+      use_automatic_resource_name
+
+      property :server, [String, URI, nil], required: true
+      property :port, Integer
+      property :token, [String, nil], required: true
+      property :insecure, [TrueClass, FalseClass], default: false
+
+      default_action :create
+
+      action :create do
+        converge_by 'compliance server auth token setup' do
+          # stash token in node.run_state to pass between resources
+          node.run_state['compliance'] ||= {}
+          if node['audit']['refresh_token']
+            Chef::Log.info 'Using refresh_token to exchange for an access token.'
+            node.run_state['compliance']['access_token'] = retrieve_access_token(server, token, insecure)
+          else
+            Chef::Log.info 'Using token attribute. This token is short lived and will expire.'
+            node.run_state['compliance']['access_token'] = token
+          end
+        end
+      end
+    end
+  end
+end

--- a/recipes/upload.rb
+++ b/recipes/upload.rb
@@ -49,6 +49,7 @@ node['audit']['profiles'].each do |owner_profile, value|
     server server
     path path
     insecure node['audit']['insecure']
+    overwrite node['audit']['overwrite']
     action :upload
   end
 end

--- a/recipes/upload.rb
+++ b/recipes/upload.rb
@@ -1,0 +1,54 @@
+# encoding: utf-8
+#
+# Cookbook Name:: audit
+# Recipe:: upload
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ensure inspec is available
+include_recipe 'audit::_inspec'
+
+# These attributes should only be set when connecting directly to Chef Compliance, otherwise they should be nil
+server = node['audit']['server']
+
+# only needed when fetching / reporting directly to Compliance Server
+compliance_token 'Compliance Token' do
+  server server
+  token node['audit']['refresh_token'] || node['audit']['token']
+  insecure node['audit']['insecure']
+end unless server.nil?
+
+# iterate over all selected profiles and upload them
+node['audit']['profiles'].each do |owner_profile, value|
+  case value
+  when Hash
+    next if value['disabled']
+    path = value['source']
+  else
+    next if value == false
+  end
+  raise "Invalid profile name '#{owner_profile}'. "\
+       "Must contain /, e.g. 'john/ssh'" if owner_profile !~ %r{\/}
+  o, p = owner_profile.split('/').last(2)
+
+  # upload profile
+  compliance_profile p do
+    owner o
+    server server
+    path path
+    insecure node['audit']['insecure']
+    action :upload
+  end
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -34,22 +34,28 @@ describe 'audit::default' do
   context 'When server and refresh_token are specified' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['audit']['collector'] = 'chef-compliance'
-        node.set['audit']['profiles'] = { 'admin/myprofile' => true }
-        node.set['audit']['server'] = 'https://my.compliance.test/api'
-        node.set['audit']['refresh_token'] = 'abcdefg'
-        node.set['audit']['insecure'] = true
+        node.override['audit']['collector'] = 'chef-compliance'
+        node.override['audit']['profiles'] = { 'admin/myprofile' => true }
+        node.override['audit']['server'] = 'https://my.compliance.test/api'
+        node.override['audit']['refresh_token'] = 'abcdefg'
+        node.override['audit']['insecure'] = true
       end.converge(described_recipe)
+    end
+
+    it 'creates compliance_token resource' do
+      expect(chef_run).to create_compliance_token('Compliance Token').with(
+        server: 'https://my.compliance.test/api',
+        insecure: true,
+        token: 'abcdefg'
+      )
     end
 
     it 'fetches and executes compliance_profile[myprofile]' do
       expect(chef_run).to fetch_compliance_profile('myprofile').with(
         server: 'https://my.compliance.test/api',
-        insecure: true,
       )
       expect(chef_run).to execute_compliance_profile('myprofile').with(
         server: 'https://my.compliance.test/api',
-        insecure: true,
       )
     end
 


### PR DESCRIPTION
### Description

This PR provides action `upload` on resource `compliance_profile`

It requires PR #91 to be merged first.

Only one mode is supported: direct communication with Compliance Server via token||refresh_token.

Usage is based on the audit hash like so:
```
default['audit']['server'] = 'https://compliance-server.test/api'
default['audit']['collector'] = 'chef-compliance'
default['audit']['token'] = nil
default['audit']['refresh_token'] = '20/cgm927J9371DRh8mZ2wp_bXRJxKPW52rtThkwQz5PzhBIcbq6VLB0LsdrfOXv_aBxprU1LTv3aUvHxe2mR-m2A=='
default['audit']['profiles'] = {
  'admin/ssh2' => {
    'source' => '/some/base_ssh.tar.gz'
  },
  'admin/linux2' => {
    'source' => '/some/base_linux.tar.gz'
  }
}
default['audit']['insecure'] = true
```

The goal is to help enable Compliance Profile uploads via automated pipeline workflow. 

### Issues Resolved

N/A

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

