### PR TITLE
Compliance profile upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,26 @@ audit: {
 }
 ```
 
+## Profile Upload to Compliance Server
+
+In order to support build cookbook mode, the `compliance_profile` resource has an `upload` action that allows uploading a compressed
+inspec compliance profile to the Compliance Server.
+
+Simply include the `upload` recipe in the run_list, with attribute overrides for the `audit` hash like so:
+
+```ruby
+audit: {
+  server: 'https://compliance-server.test/api'
+  collector: 'chef-compliance',
+  refresh_token: '21/XMEK3...',
+  profiles: {
+    'admin/ssh2': {
+      'source': '/some/base_ssh.tar.gz'
+    },
+  }
+}
+```
+
 ## Relationship with Chef Audit Mode
 
 The following tables compares the [Chef Client audit mode](https://docs.chef.io/ctl_chef_client.html#run-in-audit-mode) with this `audit` cookbook.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,3 +54,6 @@ default['audit']['interval']['time'] = 1440
 
 # quiet mode, on by default because this is testing, resources aren't converged in the normal chef sense
 default['audit']['quiet'] = true
+
+# overwrite existing profile in upload mode
+default['audit']['overwrite'] = true

--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -5,6 +5,7 @@ def retrieve_access_token(server_url, refresh_token, insecure)
   require 'inspec'
   require 'bundles/inspec-compliance/api'
   require 'bundles/inspec-compliance/http'
+  require 'bundles/inspec-compliance/configuration'
   success, msg, access_token = Compliance::API.post_refresh_token(server_url, refresh_token, insecure)
   # TODO: we return always the access token, without proper error handling
   unless success

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -13,6 +13,10 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:compliance_profile, :fetch, resource_name)
   end
 
+  def upload_compliance_profile(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:compliance_profile, :upload, resource_name)
+  end
+
   def execute_compliance_profile(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:compliance_profile, :execute, resource_name)
   end

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -153,11 +153,8 @@ class Audit
           }
           result = profile.check
           Chef::Log.info result[:summary].inspect
-          unless result[:summary][:valid]
-            raise 'Profile check failed'
-          else
-            Chef::Log.info 'Profile is valid'
-          end
+          raise 'Profile check failed' unless result[:summary][:valid]
+          Chef::Log.info 'Profile is valid'
         end
 
         converge_by 'upload compliance profile' do

--- a/libraries/profile.rb
+++ b/libraries/profile.rb
@@ -177,6 +177,8 @@ class Audit
                 Chef::Log.error "Error during profile upload: #{msg}"
               end
             end
+          else
+            Chef::Log.error 'unable to read access_token, aborting upload.'
           end
         end
       end

--- a/recipes/upload.rb
+++ b/recipes/upload.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+#
+# Cookbook Name:: audit
+# Recipe:: upload
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ensure inspec is available
+include_recipe 'audit::_inspec'
+
+# These attributes should only be set when connecting directly to Chef Compliance, otherwise they should be nil
+server = node['audit']['server']
+
+# only needed when fetching / reporting directly to Compliance Server
+compliance_token 'Compliance Token' do
+  server server
+  token node['audit']['refresh_token'] || node['audit']['token']
+  insecure node['audit']['insecure']
+end unless server.nil?
+
+# iterate over all selected profiles and upload them
+node['audit']['profiles'].each do |owner_profile, value|
+  case value
+  when Hash
+    next if value['disabled']
+    path = value['source']
+  else
+    next if value == false
+  end
+  raise "Invalid profile name '#{owner_profile}'. "\
+       "Must contain /, e.g. 'john/ssh'" if owner_profile !~ %r{\/}
+  o, p = owner_profile.split('/').last(2)
+
+  # upload profile
+  compliance_profile p do
+    owner o
+    server server
+    path path
+    insecure node['audit']['insecure']
+    overwrite node['audit']['overwrite']
+    action :upload
+  end
+end

--- a/spec/unit/recipes/upload_spec.rb
+++ b/spec/unit/recipes/upload_spec.rb
@@ -1,0 +1,67 @@
+# encoding: utf-8
+#
+# Cookbook Name:: audit
+# Spec:: upload
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'audit::upload' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+
+  context 'When server and refresh_token are specified' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.override['audit']['collector'] = 'chef-compliance'
+        node.override['audit']['profiles'] = { 'admin/myprofile' => { 'source' => '/some/path.tar.gz' } }
+        node.override['audit']['server'] = 'https://my.compliance.test/api'
+        node.override['audit']['refresh_token'] = 'abcdefg'
+        node.override['audit']['insecure'] = true
+      end.converge(described_recipe)
+    end
+
+    it 'creates compliance_token resource' do
+      expect(chef_run).to create_compliance_token('Compliance Token').with(
+        server: 'https://my.compliance.test/api',
+        insecure: true,
+        token: 'abcdefg'
+      )
+    end
+
+    it 'uploads compliance_profile[myprofile]' do
+      expect(chef_run).to upload_compliance_profile('myprofile').with(
+        server: 'https://my.compliance.test/api',
+        owner: 'admin',
+        path: '/some/path.tar.gz',
+        insecure: true,
+        overwrite: true
+      )
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
This PR provides action `upload` on resource `compliance_profile`

It replaces PR #92.

It uses inspec's `Compliance::API.upload()` and incorporates some error handling.

Only one mode is supported: direct communication with Compliance Server via token||refresh_token.

Usage is based on the audit hash like so:
```
default['audit']['server'] = 'https://compliance-server.test/api'
default['audit']['collector'] = 'chef-compliance'
default['audit']['token'] = nil
default['audit']['refresh_token'] = '20/cgm927J9371DRh8mZ2wp_bXRJxKPW52rtThkwQz5PzhBIcbq6VLB0LsdrfOXv_aBxprU1LTv3aUvHxe2mR-m2A=='
default['audit']['profiles'] = {
  'admin/ssh2' => {
    'source' => '/some/base_ssh.tar.gz'
  },
  'admin/linux2' => {
    'source' => '/some/base_linux.tar.gz'
  }
}
default['audit']['insecure'] = true
```

The goal is to help enable Compliance Profile uploads via automated pipeline workflow. 

```
Recipe: audit::upload
  * compliance_token[Compliance Token] action create[2016-09-15T13:13:16+00:00] INFO: Using refresh_token to exchange for an access token.

    - compliance server auth token setup
  * compliance_profile[ssh2] action upload[2016-09-15T13:13:16+00:00] INFO: {:valid=>true, :timestamp=>"2016-09-15T13:13:16+00:00", :location=>"/some/base_ssh.tar.gz", :profile=>"ssh", :controls=>62}
[2016-09-15T13:13:16+00:00] INFO: Profile is valid

    - run profile validation checks[2016-09-15T13:13:16+00:00] INFO: Upload from /some/base_ssh.tar.gz to: https://compliance-server.test/api/owners/admin/compliance/ssh2/tar
[2016-09-15T13:13:18+00:00] INFO: Successfully uploaded profile
```
### Issues Resolved

N/A

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
