### PR TITLE
Use the new method to retrieve access tokens and fix total_failed bug

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,8 +46,8 @@ default['audit']['fail_if_not_present'] = false
 # fail converge after posting report if any audits have failed
 default['audit']['fail_if_any_audits_failed'] = false
 
-# inspec gem version to install(e.g. '0.22.1') or 'latest'
-default['audit']['inspec_version'] = '1.0.0'
+# inspec gem version to install(e.g. '1.1.0')
+default['audit']['inspec_version'] = '1.1.0'
 
 # by default run audit every time
 default['audit']['interval']['enabled'] = false

--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -6,7 +6,8 @@ def retrieve_access_token(server_url, refresh_token, insecure)
   require 'bundles/inspec-compliance/api'
   require 'bundles/inspec-compliance/http'
   require 'bundles/inspec-compliance/configuration'
-  success, msg, access_token = Compliance::API.post_refresh_token(server_url, refresh_token, insecure)
+  # get_token_via_refresh_token is provided by the inspec-compliance plugin bundled in InSpec
+  success, msg, access_token = Compliance::API.get_token_via_refresh_token(server_url, refresh_token, insecure)
   # TODO: we return always the access token, without proper error handling
   unless success
     Chef::Log.error("Unable to get a Chef Compliance API access_token: #{msg}")

--- a/libraries/report.rb
+++ b/libraries/report.rb
@@ -27,19 +27,17 @@ class Audit
           blob = node_info
           blob[:reports] = reports
           blob[:profiles] = ownermap
-          total_failed = reports.map do |_name, report|
-            report['profiles'].map do |profile|
+
+          total_failed = reports.map do |_name, profile|
+            if !profile['controls'].empty?
               profile['controls'].map do |control|
-                if control['results']
-                  control['results'].map do |result|
-                    result['status'] != 'passed' ? 1 : 0
-                  end
-                else
-                  0
-                end
+                control['status'] != 'passed' ? 1 : 0
               end
+            else
+              0
             end
           end.flatten.reduce(:+)
+          Chef::Log.info "Total number of failed controls: #{total_failed}"
 
           # resolve owner
           o = return_or_guess_owner

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.0'
+version '1.0.1'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'


### PR DESCRIPTION
* This uses the new method to retrieve access tokens from InSpec plugin
* Fixes null pointer exception when calculating total failed controls