### PR TITLE
Fix bug when counting total failed controls in json format

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,7 +47,7 @@ default['audit']['fail_if_not_present'] = false
 default['audit']['fail_if_any_audits_failed'] = false
 
 # inspec gem version to install(e.g. '1.1.0')
-default['audit']['inspec_version'] = '1.1.0'
+default['audit']['inspec_version'] = '1.2.0'
 
 # by default run audit every time
 default['audit']['interval']['enabled'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.0.2'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'


### PR DESCRIPTION
`total_failed` only worked for `json-min` format. The current version was not working on Chef Visibility reporting.