### PR TITLE
enable chef-server fetcher attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,12 @@ default['audit']['inspec_version'] = '1.2.0'
 # chef-visibility requires inspec version 0.27.1 or above
 default['audit']['collector'] = 'chef-server'
 
+# It will use an InSpec fetcher that fetches compliance profiles via Chef Server
+# from Chef Compliance. Will be activated by default if the 'chef-server' collector
+# is used
+# fetcher possible values: chef-server
+default['audit']['fetcher'] = nil
+
 # Attributes server, insecure and token/refresh_token are only needed for the 'chef-compliance' collector
 # server format example: 'https://comp-server.example.com/api'
 default['audit']['server'] = nil

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -27,7 +27,7 @@ class Chef
         load_needed_dependencies
 
         # detect if we run in a chef client with chef server
-        load_chef_fetcher if reporters.include?('chef-server')
+        load_chef_fetcher if reporters.include?('chef-server') || node['audit']['fetcher'] == 'chef-server'
 
         # iterate through reporters
         reporters.each do |reporter|


### PR DESCRIPTION
This allows users to enable the chef-server fetcher with another reporter, e.g. Visibility

Just set the attribute `default['audit']['fetcher'] = 'chef-server'`