### PR TITLE
adding support for alternate gem source

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,19 @@ You can enable the interval and set the interval time, along with your desired p
 
 ```
 
+## Alternate Source Location for `inspec` Gem
+
+If you are not able or do not wish to pull the `inspec` gem from rubygems.org,
+you may specify an alternate source using:
+
+```
+# URI to alternate gem source (e.g. http://gems.server.com or filesytem location)
+# root of location must host the *specs.4.8.gz source index
+default['audit']['inspec_gem_source'] = 'http://internal.gem.server.com/gems'
+```
+
+Please note that all dependencies to the `inspec` gem must also be hosted in this location.
+
 ## Troubleshooting
 
 Please refer to TROUBLESHOOTING.md.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,10 @@
 # inspec gem version to install(e.g. '1.1.0')
 default['audit']['inspec_version'] = '1.2.0'
 
+# URI to alternate gem source (e.g. http://gems.server.com)
+# root of location must host the *specs.4.8.gz source index
+default['audit']['inspec_gem_source'] = nil
+
 # collector possible values: chef-server, chef-compliance, chef-visibility, json-file
 # chef-visibility requires inspec version 0.27.1 or above
 default['audit']['collector'] = 'chef-server'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,8 @@
 chef_gem 'inspec' do
   version node['audit']['inspec_version'] if node['audit']['inspec_version'] != 'latest'
   compile_time true
+  clear_sources true if node['audit']['inspec_gem_source']
+  source node['audit']['inspec_gem_source'] if node['audit']['inspec_gem_source']
   action :install
 end
 

--- a/recipes/upload.rb
+++ b/recipes/upload.rb
@@ -21,6 +21,8 @@
 chef_gem 'inspec' do
   version node['audit']['inspec_version'] if node['audit']['inspec_version'] != 'latest'
   compile_time true
+  clear_sources true if node['audit']['inspec_gem_source']
+  source node['audit']['inspec_gem_source'] if node['audit']['inspec_gem_source']
   action :install
 end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -26,6 +26,44 @@ describe 'audit::default' do
       runner.converge(described_recipe)
     end
 
+    it 'installs the inspec gem' do
+      expect(chef_run).to install_chef_gem('inspec')
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+
+
+  context 'When an inspec gem version is specified ' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.override['audit']['inspec_version'] = '0.0.0'
+      end.converge(described_recipe)
+    end
+
+    it 'installs the inspec gem with the correct version' do
+      expect(chef_run).to install_chef_gem('inspec').with(version: '0.0.0')
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+
+  context 'When an inspec gem alternate source is specified ' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.override['audit']['inspec_gem_source'] = 'http://0.0.0.0:8080'
+      end.converge(described_recipe)
+    end
+
+    it 'installs the inspec gem from the alternate source' do
+      expect(chef_run).to install_chef_gem('inspec').with(clear_sources: true)
+      expect(chef_run).to install_chef_gem('inspec').with(source: 'http://0.0.0.0:8080')
+    end
+
     it 'converges successfully' do
       expect { chef_run }.to_not raise_error
     end


### PR DESCRIPTION
### Description

This allows for sourcing the `inspec` gem from alternate location other than rubygems.org

### Issues Resolved

related to #112 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Jeremy J. Miller <jm@chef.io>