### PR TITLE
dry up chef_gem inspec resource declarations

### DIFF
--- a/recipes/inspec.rb
+++ b/recipes/inspec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 #
 # Cookbook Name:: audit
-# Recipe:: default
+# Recipe:: inspec
 #
 # Copyright 2016 Chef Software, Inc.
 #
@@ -17,6 +17,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'audit::inspec'
+chef_gem 'inspec' do
+  version node['audit']['inspec_version'] if node['audit']['inspec_version'] != 'latest'
+  compile_time true
+  clear_sources true if node['audit']['inspec_gem_source']
+  source node['audit']['inspec_gem_source'] if node['audit']['inspec_gem_source']
+  action :install
+end
 
-load_audit_handler
+load_inspec_libs

--- a/recipes/upload.rb
+++ b/recipes/upload.rb
@@ -17,17 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ensure inspec is available
-chef_gem 'inspec' do
-  version node['audit']['inspec_version'] if node['audit']['inspec_version'] != 'latest'
-  compile_time true
-  clear_sources true if node['audit']['inspec_gem_source']
-  source node['audit']['inspec_gem_source'] if node['audit']['inspec_gem_source']
-  action :install
-end
-
-load_inspec_libs
-load_audit_handler
+include_recipe 'audit::inspec'
 
 # iterate over all selected profiles and upload them
 node['audit']['profiles'].each do |profile|


### PR DESCRIPTION
### Description

Isolate the `inspec` resource to its own recipe so that it's declared only once.

### Issues Resolved

n/a

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Jeremy J. Miller <jm@chef.io>