### PR TITLE
Update fetcher for chef-server-visibility and add chef-server-compliance collector

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,3 +69,5 @@ Style/SpaceAroundOperators:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
+Style/AccessorMethodName:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ default["audit"] = {
 
 If you want the audit cookbook to retrieve compliance profiles and report to Chef Automate(Visibility) through Chef Server, set the `collector` and `profiles` attributes.
 
-This requires Chef Server version 12.11.0 and Chef Automate 0.6.0 or newer, as well as integration between the two. More details [here](https://docs.chef.io/integrate_compliance_chef_automate.html#collector-chef-server-visibility).
+This requires Chef Server version 12.11.1 and Chef Automate 0.6.6 or newer, as well as integration between the two. More details [here](https://docs.chef.io/integrate_compliance_chef_automate.html#collector-chef-server-visibility).
 
 Attributes example:
 
@@ -318,8 +318,8 @@ for each one.  For example, to report to chef-compliance and write to json file 
 
 ## Fetcher attribute
 
-To enable reporting to chef-visibility with profiles from chef-compliance, you need to have chef-server integrated with chef-compliance. You can then set the fetcher attribute to 'chef-server'.
-This will allow the audit cookbook to fetch the profile from chef-compliance.  For example:
+To enable reporting to Chef Visibility with profiles from Chef Compliance, you need to have Chef Server integrated with Chef Compliance. You can then set the `fetcher` attribute to 'chef-server'.
+This will allow the audit cookbook to fetch profiles stored in Chef Compliance. For example:
 
 ```ruby
 "audit": {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,21 +16,19 @@
 # limitations under the License.
 
 # inspec gem version to install(e.g. '1.1.0')
-default['audit']['inspec_version'] = '1.2.0'
+default['audit']['inspec_version'] = '1.5.0'
 
-# URI to alternate gem source (e.g. http://gems.server.com)
+# URI to alternate gem source (e.g. 'http://gems.server.com')
 # root of location must host the *specs.4.8.gz source index
 default['audit']['inspec_gem_source'] = nil
 
-# collector possible values: chef-server, chef-compliance, chef-visibility, chef-server-visibility, json-file
+# collector possible values: 'chef-server-visibility', 'chef-server-compliance', 'chef-compliance', 'chef-visibility', 'json-file'
 # chef-visibility requires inspec version 0.27.1 or above
-default['audit']['collector'] = 'chef-server'
+default['audit']['collector'] = 'chef-server-compliance'
 
 # It will use an InSpec fetcher that fetches compliance profiles via Chef Server
-# from Chef Compliance or Chef Automate. Will be activated by default if the collectors
-# 'chef-server' or 'chef-server-visibility' are used
-# is used
-# fetcher possible values: chef-server
+# from Chef Compliance or Chef Automate. Will be activated by default if collector
+# 'chef-server-compliance' or 'chef-server-visibility' is used. Possible values: 'chef-server'
 default['audit']['fetcher'] = nil
 
 # Attributes server, insecure and token/refresh_token are only needed for the 'chef-compliance' collector

--- a/examples/chef-server/Vagrantfile
+++ b/examples/chef-server/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure(2) do |config|
       chef.add_recipe 'audit::default'
       chef.json = {
         audit: {
-          collector: "chef-server",
+          collector: "chef-server-compliance",
           insecure: true,
           profiles: [{
             name: "linux",

--- a/examples/wrapper_audit/recipes/default.rb
+++ b/examples/wrapper_audit/recipes/default.rb
@@ -9,7 +9,7 @@
 # how you would setup chef-client to send converge data to your
 # Chef Visibility server.
 include_recipe 'visibility_win::chef_client_config'
-# Set the collector to chef-visibility instead of the default chef-server.
+# Set the collector to chef-visibility instead of the default chef-server-compliance.
 node.default['audit']['collector'] = 'chef-visibility'
 # Execute the community audit cookbook with the collector set
 include_recipe 'audit::default'

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -6,8 +6,8 @@ class Chef
     # Creates a compliance audit report
     class AuditReport < ::Chef::Handler
       def report
-        # ensure reporters is array
-        reporters = handle_reporters(node['audit']['collector'])
+        # get reporter(s) from attributes as an array
+        reporters = get_reporters(node['audit'])
 
         # collect attribute values
         server = node['audit']['server']
@@ -24,7 +24,10 @@ class Chef
         load_needed_dependencies
 
         # detect if we run in a chef client with chef server
-        load_chef_fetcher if reporters.include?('chef-server') || reporters.include?('chef-server-visibility') || node['audit']['fetcher'] == 'chef-server'
+        load_chef_fetcher if reporters.include?('chef-server') ||
+                             reporters.include?('chef-server-compliance') ||
+                             reporters.include?('chef-server-visibility') ||
+                             node['audit']['fetcher'] == 'chef-server'
 
         # iterate through reporters
         reporters.each do |reporter|
@@ -161,7 +164,7 @@ class Chef
           else
             Chef::Log.warn "unable to determine chef-server url required by inspec report collector '#{reporter}'. Skipping..."
           end
-        elsif reporter == 'chef-server'
+        elsif reporter == 'chef-server-compliance' || reporter == 'chef-server' # chef-server is legacy reporter
           chef_url = server || base_chef_server_url
           chef_org = Chef::Config[:chef_server_url].split('/').last
           if chef_url

--- a/files/default/vendor/chef-server/fetcher.rb
+++ b/files/default/vendor/chef-server/fetcher.rb
@@ -49,6 +49,18 @@ module ChefServer
       Chef::Config[:chef_server_url].split('/').last
     end
 
+    def self.url_prefix
+      if defined?(Chef) &&
+         defined?(Chef.node) &&
+         defined?(Chef.node.attributes) &&
+         Chef.node.attributes['audit'] &&
+         get_reporters(Chef.node.attributes['audit']).include?('chef-server-visibility')
+        ''
+      else
+        '/compliance'
+      end
+    end
+
     def self.target_url(profile, config)
       o, p = profile.split('/')
       reqpath ="organizations/#{chef_server_org}/owners/#{o}/compliance/#{p}/tar"
@@ -58,7 +70,7 @@ module ChefServer
         Chef::Config[:ssl_verify_mode] = :verify_none
       end
 
-      construct_url(chef_server_url_base + '/compliance/', reqpath)
+      construct_url(chef_server_url_base + url_prefix + '/', reqpath)
     end
 
     #

--- a/files/default/vendor/chef-server/fetcher.rb
+++ b/files/default/vendor/chef-server/fetcher.rb
@@ -50,15 +50,19 @@ module ChefServer
     end
 
     def self.url_prefix
-      if defined?(Chef) &&
-         defined?(Chef.node) &&
-         defined?(Chef.node.attributes) &&
-         Chef.node.attributes['audit'] &&
-         get_reporters(Chef.node.attributes['audit']).include?('chef-server-visibility')
+      if chef_server_visibility?
         ''
       else
         '/compliance'
       end
+    end
+
+    def self.chef_server_visibility?
+      attributes_exist? && Chef.node.attributes['audit'] && get_reporters(Chef.node.attributes['audit']).include?('chef-server-visibility')
+    end
+
+    def self.attributes_exist?
+      defined?(Chef) && defined?(Chef.node) && defined?(Chef.node.attributes)
     end
 
     def self.target_url(profile, config)

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -121,10 +121,11 @@ module ReportHelpers
 
   # taking node['audit'] as parameter so that it can be called from the chef-server fetcher as well
   # audit['collector'] is the legacy reporter,
-  # deprecated in favour of ['audit']['reporter']
+  # deprecated in favour of audit['reporter']
   def get_reporters(audit)
     if audit['collector'] && audit['reporter'].nil?
-      Chef::Log.warn("node ['audit']['collector'] is deprecated and will be removed from the next major version of the cookbook. Please use node ['audit']['reporter']")
+      # TODO: uncomment the log warn once Chris +1's the change and we update attributes and README as well.
+      # Chef::Log.warn("node ['audit']['collector'] is deprecated and will be removed from the next major version of the cookbook. Please use node ['audit']['reporter']")
       return handle_reporters(audit['collector'])
     end
     handle_reporters(audit['reporter'])

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -118,6 +118,17 @@ module ReportHelpers
     require libpath
     Chef::Config.send('report_handlers') << Chef::Handler::AuditReport.new
   end
+
+  # taking node['audit'] as parameter so that it can be called from the chef-server fetcher as well
+  # audit['collector'] is the legacy reporter,
+  # deprecated in favour of ['audit']['reporter']
+  def get_reporters(audit)
+    if audit['collector'] && audit['reporter'].nil?
+      Chef::Log.warn("node ['audit']['collector'] is deprecated and will be removed from the next major version of the cookbook. Please use node ['audit']['reporter']")
+      return handle_reporters(audit['collector'])
+    end
+    handle_reporters(audit['reporter'])
+  end
 end
 
 ::Chef::Recipe.send(:include, ReportHelpers)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.2.0'
+version '2.3.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'


### PR DESCRIPTION
Fixes https://github.com/chef-cookbooks/audit/issues/158

The chef-server fetcher is also using a different fetching URL when reporter chef-server-visibility is used.

I was also thinking to introduce replace the current `chef-server` fetcher with `chef-server-compliance` and possibly add a `chef-server-automate` reporter. In the interest of keeping this change small for now. I reverted the fetcher change.

Attributes and README are not fully updated. Waiting for 👍  before doing that.