### PR TITLE
Removed the colon from the json-file filename

### DIFF
--- a/libraries/collector_classes.rb
+++ b/libraries/collector_classes.rb
@@ -332,7 +332,7 @@ class Collector
     end
 
     def write_to_file(report, timestamp)
-      filename = 'inspec' << '-' << timestamp << '.json'
+      filename = 'inspec' << '-' << timestamp.tr(':', '-') << '.json'
       path = File.expand_path("../../#{filename}", __FILE__)
       Chef::Log.warn "Filename is #{path}"
       json_file = File.new(path, 'w')

--- a/spec/unit/libraries/json_file_spec.rb
+++ b/spec/unit/libraries/json_file_spec.rb
@@ -9,7 +9,7 @@ require_relative '../../../libraries/collector_classes'
 describe 'Collector::JsonFile methods' do
   it 'writes the report to a file on disk' do
     report = 'some info'
-    timestamp = Time.now.utc.to_s.tr(' ', '_')
+    timestamp = Time.now.utc.to_s.tr(' ', '_').tr(':', '-')
     @jsonfile = Collector::JsonFile.new(report, timestamp).send_report
     expected_file_path = File.expand_path("../../../../inspec-#{timestamp}.json", __FILE__)
     expect(File).to exist("#{expected_file_path}")


### PR DESCRIPTION
### Description

When writing the json-file to the filesystem the generated filename included a colon which caused an exception on windows systems as its an illegal char.

### Issues Resolved

#173 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [n/a] New functionality includes testing.
- [n/a] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: gbright <gary.bright@niu-solutions.com>