### PR TITLE
change json-file filename

### DIFF
--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -174,7 +174,7 @@ class Chef
             Chef::Log.warn "unable to determine chef-server url required by inspec report collector '#{reporter}'. Skipping..."
           end
         elsif reporter == 'json-file'
-          timestamp = Time.now.utc.to_s.tr(' ', '_')
+          timestamp = Time.now.utc.strftime('%Y%m%d%H%M%S')
           Collector::JsonFile.new(report, timestamp).send_report
         else
           Chef::Log.warn "#{reporter} is not a supported InSpec report collector"

--- a/spec/unit/libraries/json_file_spec.rb
+++ b/spec/unit/libraries/json_file_spec.rb
@@ -9,7 +9,7 @@ require_relative '../../../libraries/collector_classes'
 describe 'Collector::JsonFile methods' do
   it 'writes the report to a file on disk' do
     report = 'some info'
-    timestamp = Time.now.utc.to_s.tr(' ', '_')
+    timestamp = Time.now.utc.strftime('%Y%m%d%H%M%S')
     @jsonfile = Collector::JsonFile.new(report, timestamp).send_report
     expected_file_path = File.expand_path("../../../../inspec-#{timestamp}.json", __FILE__)
     expect(File).to exist("#{expected_file_path}")


### PR DESCRIPTION
### Description

Changes timestamp format so that filename does not contain colon which causes errors on Windows.

```
irb(main):027:0> "inspec-#{Time.now.strftime('%Y%m%d%H%M%S')}.json"
=> "inspec-20161202230551.json"
irb(main):028:0>
```

### Issues Resolved

https://github.com/chef-cookbooks/audit/issues/173

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Jeremy J. Miller <jm@chef.io>