### PR TITLE
throw chef-client exception if requested by users

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -79,6 +79,32 @@ suites:
           - git: https://github.com/dev-sec/tests-ssh-hardening.git
           - name: ssh
             supermarket: hardening/ssh-hardening
+  # default setting does not fail for missing profile
+  - name: missing-profile-no-fail
+    run_list:
+      - recipe[test_helper::setup]
+      - recipe[audit::default]
+    attributes:
+      audit:
+        collector: json-file
+        profiles:
+          - name: ssh-hardening
+            url: https://github.com/dev-sec/this-is-not-available.zip
+    includes:
+      - ubuntu-14.04
+  - name: missing-profile-fail
+    run_list:
+      - recipe[test_helper::setup]
+      - recipe[audit::default]
+    attributes:
+      audit:
+        collector: json-file
+        fail_if_not_present: true
+        profiles:
+          - name: ssh-hardening
+            url: https://github.com/dev-sec/this-is-not-available.zip
+    includes:
+      - ubuntu-14.04
   - name: compliance # compliance direct reporting
     run_list:
       - recipe[audit::default]

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,9 @@ matrix:
   - rvm: 2.3.1
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-ubuntu-1404'
+  - rvm: 2.3.1
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='missing-profile-no-fail-ubuntu-1404'
+  - rvm: 2.3.1
+    script: bundle exec rake $SUITE && exit 1 || echo "OK"
+    env: SUITE=test:integration OS='missing-profile-fail-ubuntu-1404'


### PR DESCRIPTION
### Description

This enables user to fail a chef-client run, if a some parts fail during reporting stage

### Issues Resolved

fixes #166 

Thank you @stevendanna for highlighting the solution