### PR TITLE
Fix issue with interval being removed because of chef-client cookbook cleanup

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -69,11 +69,15 @@ module ReportHelpers
     cs.to_s
   end
 
+  def report_timing_file
+    # Will create and return the complete folder path for the chef cache location and the passed in value
+    ::File.join(Chef::FileCache.create_cache_path('compliance'), 'report_timing.json')
+  end
+
   def profile_overdue_to_run?(interval)
     # Calculate when a report was last created so we delay the next report if necessary
-    file = File.expand_path('../../report_timing.json', __FILE__)
-    return true unless ::File.exist?(file)
-    seconds_since_last_run = Time.now - ::File.mtime(file)
+    return true unless ::File.exist?(report_timing_file)
+    seconds_since_last_run = Time.now - ::File.mtime(report_timing_file)
     seconds_since_last_run > interval
   end
 
@@ -90,9 +94,8 @@ module ReportHelpers
 
   # used for interval timing
   def create_timestamp_file
-    path = File.expand_path('../../report_timing.json', __FILE__)
     timestamp = Time.now.utc
-    timestamp_file = File.new(path, 'w')
+    timestamp_file = File.new(report_timing_file, 'w')
     timestamp_file.puts(timestamp)
     timestamp_file.close
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
 # encoding: utf-8
 require 'chefspec'
 require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  config.file_cache_path = Chef::Config[:file_cache_path]
+end

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -15,8 +15,12 @@ describe ReportHelpers do
     expect(symbol_tests).to eq([{:name=>"ssh", :url=>"https://github.com/dev-sec/tests-ssh-hardening"}])
   end
 
+  it 'report_timing_file returns where the report timing file is located' do
+    expect(@report.report_timing_file).to eq("#{Chef::Config[:file_cache_path]}/compliance/report_timing.json")
+  end
+
   it 'create_timestamp_file creates a new file' do
-    expected_file_path = File.expand_path("../../../../report_timing.json", __FILE__)
+    expected_file_path = @report.report_timing_file
     @report.create_timestamp_file
     expect(File).to exist("#{expected_file_path}")
     File.delete("#{expected_file_path}")


### PR DESCRIPTION
### Description

This solves an issue where the chef-client cookbook cleanup step removes the report_timing.json file from the cache.  Upon looking into chef client you can see the following:

https://github.com/chef/chef/blob/master/lib/chef/cookbook/synchronizer.rb#L184-L195
https://github.com/chef/chef/blob/master/lib/chef/policy_builder/expand_node_object.rb#L219-L223

And upon setting the logs to info and running chef client you can see the following:

```
[2017-01-04T23:01:25+00:00] INFO: Removing cookbooks/audit/report_timing.json from the cache; it is no longer needed by chef-client.
```

This resolves the issue by putting the file in the chef cache directory specified by chef-client under a compliance folder.  

### Issues Resolved

N/A

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
