### PR TITLE
make automate integration tests optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ matrix:
     - rm ~/.ssh/kitchen-key-compliance.*
     after_success:
     - bundle exec rake $SUITE[destroy]
+  allow_failures:
+  - env: SUITE=test:kitchen_automate
 env:
   global:
   # AWS keys:


### PR DESCRIPTION
Automate integration tests do not run for external PRs. Therefore we should make them optional.