### PR TITLE
Type the inspec profile attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
   gem 'berkshelf', '>= 5.0'
   gem 'chefspec',  '>= 5.2'
   gem 'coveralls', '~> 0.8.2', require: false
+  gem 'rb-readline'
 end
 
 group :integration do

--- a/README.md
+++ b/README.md
@@ -444,6 +444,17 @@ Please refer to TROUBLESHOOTING.md.
 
 Please let us know if you have any [issues](https://github.com/chef-cookbooks/audit/issues), we are happy to help.
 
+## Run the tests for this cookbook:
+
+```bash
+bundle install
+bundle exec rake style
+# run all ChefSpec tests
+bundle exec rspec
+# run a specific test
+bundle exec rspec ./spec/unit/libraries/visibility_spec.rb
+```
+
 ## How to release the `audit` cookbook
 
 * Cookbook source located here: (https://github.com/chef-cookbooks/audit)

--- a/libraries/collector_classes.rb
+++ b/libraries/collector_classes.rb
@@ -72,6 +72,34 @@ class Collector
       end
     end
 
+    # Some document stores like ElasticSearch don't like values that change type
+    # This function converts all profile attribute defaults to string and
+    # adds a 'type' key to store the original type
+    def typed_attributes(profiles)
+      return profiles unless profiles.class == Array && !profiles.empty?
+      profiles.each { |profile|
+        next unless profile['attributes'].class == Array && !profile['attributes'].empty?
+        profile['attributes'].map { |attrib|
+          case attrib['options']['default'].class.to_s
+          when 'String'
+            attrib['options']['type'] = 'string'
+          when 'FalseClass'
+            attrib['options']['type'] = 'boolean'
+            attrib['options']['default'] = attrib['options']['default'].to_s
+          when 'Fixnum'
+            attrib['options']['type'] = 'int'
+            attrib['options']['default'] = attrib['options']['default'].to_s
+          when 'Float'
+            attrib['options']['type'] = 'float'
+            attrib['options']['default'] = attrib['options']['default'].to_s
+          else
+            Chef::Log.warn "enriched_report: unsupported data type(#{attrib['options']['default'].class}) for attribute #{attrib['options']['name']}"
+            attrib['options']['type'] = 'unknown'
+          end
+        }
+      }
+    end
+
     # ***************************************************************************************
     # TODO: We could likely simplify/remove alot of the extra logic we have here with a small
     # revamp of the visibility expected input.
@@ -88,6 +116,9 @@ class Collector
 
       # remove nil profiles if any
       final_report['profiles'].select! { |p| p }
+
+      # set types for profile attributes
+      final_report['profiles'] = typed_attributes(final_report['profiles'])
 
       # add some additional fields to ease report parsing
       final_report['event_type'] = 'inspec'

--- a/spec/data/mock.rb
+++ b/spec/data/mock.rb
@@ -4,6 +4,39 @@ class MockData
   end
 
   def self.inspec_results
-    "{\"version\":\"1.2.1\",\"profiles\":[{\"name\":\"tmp_compliance_profile\",\"title\":\"/tmp Compliance Profile\",\"summary\":\"An Example Compliance Profile\",\"version\":\"0.1.1\",\"maintainer\":\"Nathen Harvey <nharvey@chef.io>\",\"license\":\"Apache 2.0 License\",\"copyright\":\"Nathen Harvey <nharvey@chef.io>\",\"supports\":[],\"controls\":[{\"title\":\"A /tmp directory must exist\",\"desc\":\"A /tmp directory must exist\",\"impact\":0.3,\"refs\":[],\"tags\":{},\"code\":\"control 'tmp-1.0' do\\n  impact 0.3\\n  title 'A /tmp directory must exist'\\n  desc 'A /tmp directory must exist'\\n  describe file '/tmp' do\\n    it { should be_directory }\\n  end\\nend\\n\",\"source_location\":{\"ref\":\"/Users/vjeffrey/code/delivery/insights/data_generator/chef-client/cache/cookbooks/test-cookbook/recipes/../files/default/compliance_profiles/tmp_compliance_profile/controls/tmp.rb\",\"line\":3},\"id\":\"tmp-1.0\",\"results\":[{\"status\":\"passed\",\"code_desc\":\"File /tmp should be directory\",\"run_time\":0.002312,\"start_time\":\"2016-10-19 11:09:43 -0400\"}]},{\"title\":\"/tmp directory is owned by the root user\",\"desc\":\"The /tmp directory must be owned by the root user\",\"impact\":0.3,\"refs\":[{\"url\":\"https://pages.chef.io/rs/255-VFB-268/images/compliance-at-velocity2015.pdf\",\"ref\":\"Compliance Whitepaper\"}],\"tags\":{\"production\":null,\"development\":null,\"identifier\":\"value\",\"remediation\":\"https://github.com/chef-cookbooks/audit\"},\"code\":\"control 'tmp-1.1' do\\n  impact 0.3\\n  title '/tmp directory is owned by the root user'\\n  desc 'The /tmp directory must be owned by the root user'\\n  tag 'production','development'\\n  tag identifier: 'value'\\n  tag remediation: 'https://github.com/chef-cookbooks/audit'\\n  ref 'Compliance Whitepaper', url: 'https://pages.chef.io/rs/255-VFB-268/images/compliance-at-velocity2015.pdf'\\n  describe file '/tmp' do\\n    it { should be_owned_by 'root' }\\n  end\\nend\\n\",\"source_location\":{\"ref\":\"/Users/vjeffrey/code/delivery/insights/data_generator/chef-client/cache/cookbooks/test-cookbook/recipes/../files/default/compliance_profiles/tmp_compliance_profile/controls/tmp.rb\",\"line\":12},\"id\":\"tmp-1.1\",\"results\":[{\"status\":\"passed\",\"code_desc\":\"File /tmp should be owned by \\\"root\\\"\",\"run_time\":0.028845,\"start_time\":\"2016-10-19 11:09:43 -0400\"}]}],\"groups\":[{\"title\":\"/tmp Compliance Profile\",\"controls\":[\"tmp-1.0\",\"tmp-1.1\"],\"id\":\"controls/tmp.rb\"}],\"attributes\":[]}],\"other_checks\":[],\"statistics\":{\"duration\":0.032332}}"
+    {"version"=>"1.2.1",
+     "profiles"=>
+      [{"name"=>"tmp_compliance_profile",
+        "title"=>"/tmp Compliance Profile",
+        "summary"=>"An Example Compliance Profile",
+        "version"=>"0.1.1",
+        "maintainer"=>"Nathen Harvey <nharvey@chef.io>",
+        "license"=>"Apache 2.0 License",
+        "copyright"=>"Nathen Harvey <nharvey@chef.io>",
+        "supports"=>[],
+        "controls"=>
+         [{"title"=>"A /tmp directory must exist",
+           "desc"=>"A /tmp directory must exist",
+           "impact"=>0.3,
+           "refs"=>[],
+           "tags"=>{},
+           "code"=>"control 'tmp-1.0' do\n  impact 0.3\n  title 'A /tmp directory must exist'\n  desc 'A /tmp directory must exist'\n  describe file '/tmp' do\n    it { should be_directory }\n  end\nend\n",
+           "source_location"=>{"ref"=>"/Users/vjeffrey/code/delivery/insights/data_generator/chef-client/cache/cookbooks/test-cookbook/recipes/../files/default/compliance_profiles/tmp_compliance_profile/controls/tmp.rb", "line"=>3},
+           "id"=>"tmp-1.0",
+           "results"=>[{"status"=>"passed", "code_desc"=>"File /tmp should be directory", "run_time"=>0.002312, "start_time"=>"2016-10-19 11:09:43 -0400"}]},
+          {"title"=>"/tmp directory is owned by the root user",
+           "desc"=>"The /tmp directory must be owned by the root user",
+           "impact"=>0.3,
+           "refs"=>[{"url"=>"https://pages.chef.io/rs/255-VFB-268/images/compliance-at-velocity2015.pdf", "ref"=>"Compliance Whitepaper"}],
+           "tags"=>{"production"=>nil, "development"=>nil, "identifier"=>"value", "remediation"=>"https://github.com/chef-cookbooks/audit"},
+           "code"=>
+            "control 'tmp-1.1' do\n  impact 0.3\n  title '/tmp directory is owned by the root user'\n  desc 'The /tmp directory must be owned by the root user'\n  tag 'production','development'\n  tag identifier: 'value'\n  tag remediation: 'https://github.com/chef-cookbooks/audit'\n  ref 'Compliance Whitepaper', url: 'https://pages.chef.io/rs/255-VFB-268/images/compliance-at-velocity2015.pdf'\n  describe file '/tmp' do\n    it { should be_owned_by 'root' }\n  end\nend\n",
+           "source_location"=>{"ref"=>"/Users/vjeffrey/code/delivery/insights/data_generator/chef-client/cache/cookbooks/test-cookbook/recipes/../files/default/compliance_profiles/tmp_compliance_profile/controls/tmp.rb", "line"=>12},
+           "id"=>"tmp-1.1",
+           "results"=>[{"status"=>"passed", "code_desc"=>"File /tmp should be owned by \"root\"", "run_time"=>0.028845, "start_time"=>"2016-10-19 11:09:43 -0400"}]}],
+        "groups"=>[{"title"=>"/tmp Compliance Profile", "controls"=>["tmp-1.0", "tmp-1.1"], "id"=>"controls/tmp.rb"}],
+        "attributes"=>[{"name"=>"syslog_pkg", "options"=>{"default"=>"rsyslog", "description"=>"syslog package..."}}]}],
+      "other_checks"=>[],
+      "statistics"=>{"duration"=>0.032332}}
   end
 end

--- a/spec/unit/libraries/compliance_spec.rb
+++ b/spec/unit/libraries/compliance_spec.rb
@@ -12,13 +12,22 @@ describe 'Collector::ChefCompliance methods' do
     url = 'https://192.168.33.201/api'
     node_info = {:node=>"default-ubuntu-1404", :os=>{:release=>"14.04", :family=>"ubuntu"}, :environment=>"_default"}
     raise_if_unreachable = true
-    @report = {"version"=>"1.2.1", "controls"=>[{"id"=>"basic-4", "status"=>"passed", "code_desc"=>"File /etc/ssh/sshd_config should be owned by \"root\"", "profile_id"=>"ssh"}], "statistics"=>{"duration"=>0.355784812}}
+    @report = {
+      "version"=>"1.2.1",
+      "controls"=>[{"id"=>"basic-4", "status"=>"passed", "code_desc"=>"File /etc/ssh/sshd_config should be owned by \"root\"", "profile_id"=>"ssh"}], "statistics"=>{"duration"=>0.355784812}
+    }
     compliance_profiles = [{:owner=> 'admin', :profile_id=> 'ssh'}]
-    @enriched_report_expected = "{\"node\":\"default-ubuntu-1404\",\"os\":{\"release\":\"14.04\",\"family\":\"ubuntu\"},\"environment\":\"_default\",\"reports\":{\"ssh\":{\"version\":\"1.2.1\",\"controls\":[{\"id\":\"basic-4\",\"status\":\"passed\",\"code_desc\":\"File \/etc\/ssh\/sshd_config should be owned by \\\"root\\\"\",\"profile_id\":\"ssh\"}],\"statistics\":{\"duration\":0.355784812}}},\"profiles\":{\"ssh\":\"admin\"}}"
+    @enriched_report_expected = {
+      "node"=>"default-ubuntu-1404",
+      "os"=>{"release"=>"14.04", "family"=>"ubuntu"},
+      "environment"=>"_default",
+      "reports"=>{"ssh"=>{"version"=>"1.2.1", "controls"=>[{"id"=>"basic-4", "status"=>"passed", "code_desc"=>"File /etc/ssh/sshd_config should be owned by \"root\"", "profile_id"=>"ssh"}], "statistics"=>{"duration"=>0.355784812}}},
+      "profiles"=>{"ssh"=>"admin"}
+    }
     @chef_compliance = Collector::ChefCompliance.new(url, node_info, raise_if_unreachable, compliance_profiles, @report)
   end
 
   it 'enriches the report correctly' do
-    expect(@chef_compliance.enriched_report(@report)).to eq(@enriched_report_expected)
+    expect(JSON.parse(@chef_compliance.enriched_report(@report))).to eq(@enriched_report_expected)
   end
 end

--- a/spec/unit/libraries/visibility_spec.rb
+++ b/spec/unit/libraries/visibility_spec.rb
@@ -27,7 +27,52 @@ describe 'Collector::ChefVisibility methods' do
     run_id = '3f0536f7-3361-4bca-ae53-b45118dceb5d'
     insecure = false
     report = MockData.inspec_results
-    @enriched_report_expected =  "{\"profiles\":[{\"name\":\"tmp_compliance_profile\",\"title\":\"/tmp Compliance Profile\",\"summary\":\"An Example Compliance Profile\",\"version\":\"0.1.1\",\"maintainer\":\"Nathen Harvey <nharvey@chef.io>\",\"license\":\"Apache 2.0 License\",\"copyright\":\"Nathen Harvey <nharvey@chef.io>\",\"supports\":[],\"controls\":[{\"title\":\"A /tmp directory must exist\",\"desc\":\"A /tmp directory must exist\",\"impact\":0.3,\"refs\":[],\"tags\":{},\"code\":\"control 'tmp-1.0' do\\n  impact 0.3\\n  title 'A /tmp directory must exist'\\n  desc 'A /tmp directory must exist'\\n  describe file '/tmp' do\\n    it { should be_directory }\\n  end\\nend\\n\",\"source_location\":{\"ref\":\"/Users/vjeffrey/code/delivery/insights/data_generator/chef-client/cache/cookbooks/test-cookbook/recipes/../files/default/compliance_profiles/tmp_compliance_profile/controls/tmp.rb\",\"line\":3},\"id\":\"tmp-1.0\",\"results\":[{\"status\":\"passed\",\"code_desc\":\"File /tmp should be directory\",\"run_time\":0.002312,\"start_time\":\"2016-10-19 11:09:43 -0400\"}]},{\"title\":\"/tmp directory is owned by the root user\",\"desc\":\"The /tmp directory must be owned by the root user\",\"impact\":0.3,\"refs\":[{\"url\":\"https://pages.chef.io/rs/255-VFB-268/images/compliance-at-velocity2015.pdf\",\"ref\":\"Compliance Whitepaper\"}],\"tags\":{\"production\":null,\"development\":null,\"identifier\":\"value\",\"remediation\":\"https://github.com/chef-cookbooks/audit\"},\"code\":\"control 'tmp-1.1' do\\n  impact 0.3\\n  title '/tmp directory is owned by the root user'\\n  desc 'The /tmp directory must be owned by the root user'\\n  tag 'production','development'\\n  tag identifier: 'value'\\n  tag remediation: 'https://github.com/chef-cookbooks/audit'\\n  ref 'Compliance Whitepaper', url: 'https://pages.chef.io/rs/255-VFB-268/images/compliance-at-velocity2015.pdf'\\n  describe file '/tmp' do\\n    it { should be_owned_by 'root' }\\n  end\\nend\\n\",\"source_location\":{\"ref\":\"/Users/vjeffrey/code/delivery/insights/data_generator/chef-client/cache/cookbooks/test-cookbook/recipes/../files/default/compliance_profiles/tmp_compliance_profile/controls/tmp.rb\",\"line\":12},\"id\":\"tmp-1.1\",\"results\":[{\"status\":\"passed\",\"code_desc\":\"File /tmp should be owned by \\\"root\\\"\",\"run_time\":0.028845,\"start_time\":\"2016-10-19 11:09:43 -0400\"}]}],\"groups\":[{\"title\":\"/tmp Compliance Profile\",\"controls\":[\"tmp-1.0\",\"tmp-1.1\"],\"id\":\"controls/tmp.rb\"}],\"attributes\":[]}],\"event_type\":\"inspec\",\"event_action\":\"exec\",\"compliance_summary\":{\"total\":2,\"passed\":{\"total\":2},\"skipped\":{\"total\":0},\"failed\":{\"total\":0,\"minor\":0,\"major\":0,\"critical\":0},\"status\":\"passed\",\"node_name\":\"chef-client.solo\",\"end_time\":\"2016-07-19T19:19:19+01:00\",\"duration\":0.032332,\"inspec_version\":\"1.2.1\"},\"entity_uuid\":\"aaaaaaaa-709a-475d-bef5-zzzzzzzzzzzz\",\"run_id\":\"3f0536f7-3361-4bca-ae53-b45118dceb5d\"}"
+    @enriched_report_expected = { "profiles"=>
+      [{"name"=>"tmp_compliance_profile",
+        "title"=>"/tmp Compliance Profile",
+        "summary"=>"An Example Compliance Profile",
+        "version"=>"0.1.1",
+        "maintainer"=>"Nathen Harvey <nharvey@chef.io>",
+        "license"=>"Apache 2.0 License",
+        "copyright"=>"Nathen Harvey <nharvey@chef.io>",
+        "supports"=>[],
+        "controls"=>
+         [ {"title"=>"A /tmp directory must exist",
+            "desc"=>"A /tmp directory must exist",
+            "impact"=>0.3,
+            "refs"=>[],
+            "tags"=>{},
+            "code"=>
+              "control 'tmp-1.0' do\n  impact 0.3\n  title 'A /tmp directory must exist'\n  desc 'A /tmp directory must exist'\n  describe file '/tmp' do\n    it { should be_directory }\n  end\nend\n",
+            "source_location"=>{"ref"=>"/Users/vjeffrey/code/delivery/insights/data_generator/chef-client/cache/cookbooks/test-cookbook/recipes/../files/default/compliance_profiles/tmp_compliance_profile/controls/tmp.rb", "line"=>3},
+            "id"=>"tmp-1.0",
+            "results"=>[{"status"=>"passed", "code_desc"=>"File /tmp should be directory", "run_time"=>0.002312, "start_time"=>"2016-10-19 11:09:43 -0400"}]},
+           {"title"=>"/tmp directory is owned by the root user",
+            "desc"=>"The /tmp directory must be owned by the root user",
+            "impact"=>0.3,
+            "refs"=>[{"url"=>"https://pages.chef.io/rs/255-VFB-268/images/compliance-at-velocity2015.pdf", "ref"=>"Compliance Whitepaper"}],
+            "tags"=>{"production"=>nil, "development"=>nil, "identifier"=>"value", "remediation"=>"https://github.com/chef-cookbooks/audit"},
+            "code"=>
+              "control 'tmp-1.1' do\n  impact 0.3\n  title '/tmp directory is owned by the root user'\n  desc 'The /tmp directory must be owned by the root user'\n  tag 'production','development'\n  tag identifier: 'value'\n  tag remediation: 'https://github.com/chef-cookbooks/audit'\n  ref 'Compliance Whitepaper', url: 'https://pages.chef.io/rs/255-VFB-268/images/compliance-at-velocity2015.pdf'\n  describe file '/tmp' do\n    it { should be_owned_by 'root' }\n  end\nend\n",
+            "source_location"=>{"ref"=>"/Users/vjeffrey/code/delivery/insights/data_generator/chef-client/cache/cookbooks/test-cookbook/recipes/../files/default/compliance_profiles/tmp_compliance_profile/controls/tmp.rb", "line"=>12},
+            "id"=>"tmp-1.1",
+            "results"=>[{"status"=>"passed", "code_desc"=>"File /tmp should be owned by \"root\"", "run_time"=>0.028845, "start_time"=>"2016-10-19 11:09:43 -0400"}]}],
+        "groups"=>[{"title"=>"/tmp Compliance Profile", "controls"=>["tmp-1.0", "tmp-1.1"], "id"=>"controls/tmp.rb"}],
+        "attributes"=>[{"name"=>"syslog_pkg", "options"=>{"default"=>"rsyslog", "description"=>"syslog package...", "type"=>"string"}}]}],
+      "event_type"=>"inspec",
+      "event_action"=>"exec",
+      "compliance_summary"=>{
+        "total"=>2,
+        "passed"=>{"total"=>2},
+        "skipped"=>{"total"=>0},
+        "failed"=>{"total"=>0, "minor"=>0, "major"=>0, "critical"=>0},
+        "status"=>"passed",
+        "node_name"=>"chef-client.solo",
+        "end_time"=>"2016-07-19T19:19:19+01:00",
+        "duration"=>0.032332,
+        "inspec_version"=>"1.2.1"},
+      "entity_uuid"=>"aaaaaaaa-709a-475d-bef5-zzzzzzzzzzzz",
+      "run_id"=>"3f0536f7-3361-4bca-ae53-b45118dceb5d"}
     @viz = Collector::ChefVisibility.new(entity_uuid, run_id, MockData.node_info, insecure, report)
   end
 
@@ -83,9 +128,39 @@ describe 'Collector::ChefVisibility methods' do
     expect(@viz.count_controls(profi)).to eq(expected_count)
   end
 
+  it 'sets the attribute types like TypeScript' do
+    profiles = [
+      {
+        "attributes"=>[
+          { "name"=>"syslog_pkg",
+            "options"=>{ "default"=>"rsyslog", "description"=>"a string" } },
+          { "name"=>"sysctl_forwarding",
+            "options"=>{ "default"=>false, "description"=>"a boolean" } },
+          { "name"=>"some_number",
+            "options"=>{ "default"=>0, "description"=>"a number" } },
+          { "name"=>"some_float",
+            "options"=>{ "default"=>0.8, "description"=>"a bloody float" } },
+          { "name"=>"some_array",
+            "options"=>{ "default"=>[], "description"=>"a bloody array" } }
+        ]
+      }
+    ]
+    # poor man's deep clone
+    types_profiles = JSON.parse(profiles.to_json)
+    types_profiles[0]['attributes'][0]['options']['type'] = 'string'
+    types_profiles[0]['attributes'][1]['options']['type'] = 'boolean'
+    types_profiles[0]['attributes'][1]['options']['default'] = 'false'
+    types_profiles[0]['attributes'][2]['options']['type'] = 'int'
+    types_profiles[0]['attributes'][2]['options']['default'] = '0'
+    types_profiles[0]['attributes'][3]['options']['type'] = 'float'
+    types_profiles[0]['attributes'][3]['options']['default'] = '0.8'
+    types_profiles[0]['attributes'][4]['options']['type'] = 'unknown'
+    expect(@viz.typed_attributes(profiles)).to eq(types_profiles)
+  end
+
   it 'enriches report correctly with the most test coverage' do
     allow(DateTime).to receive(:now).and_return(DateTime.parse('2016-07-19T19:19:19+01:00'))
-    expect(@viz.enriched_report(JSON.parse(MockData.inspec_results))).to eq(@enriched_report_expected)
+    expect(JSON.parse(@viz.enriched_report(MockData.inspec_results))).to eq(@enriched_report_expected)
   end
 
   it 'is not sending report when entity_uuid is missing' do


### PR DESCRIPTION
Some document stores like ElasticSearch don't like values that change type. This change converts all profile attribute defaults to string and adds a 'type' key to store the original type.

Some testing improvements.