### PR TITLE
Use `chef-server-compliance` vs `chef-server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ node.default['audit']['profiles'].push("path": "#{PROFILES_PATH}/mylinux-failure
 
 ```ruby
 "audit": {
-  "collector": "chef-server",
+  "collector": "chef-server-compliance",
   "inspec_version": "1.2.1",
   "profiles": [
     # profile from Chef Compliance
@@ -154,7 +154,7 @@ You can also configure in a policyfile like this:
 
 ```ruby
 default["audit"] = {
-  "collector" => "chef-server",
+  "collector" => "chef-server-compliance",
   "profiles" => [
     {
       "name": "linux",


### PR DESCRIPTION
Modify `README.md` to reference the `chef-server-compliance` collector change introduced [here](https://github.com/chef-cookbooks/audit/commit/92f0601c70a5f8013f22c081203be98768e8ceb1).