### PR TITLE
Only install InSpec if not installed or version provided

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -114,3 +114,11 @@ suites:
         token: <%= ENV['COMPLIANCE_ACCESSTOKEN'] %>
         owner: admin
         profiles: *profiles
+  - name: gem-install-version
+    run_list:
+      - recipe[test_helper::install_inspec_1_17]
+      - recipe[audit::default]
+    attributes:
+      audit:
+        collector: json-file
+        inspec_version: 1.18.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,12 @@ matrix:
     script: bundle exec rake $SUITE && exit 1 || echo "OK"
     env: SUITE=test:integration OS='missing-profile-fail-ubuntu-1404'
   - rvm: 2.3.1
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='gem-install-version-centos-7'
+  - rvm: 2.3.1
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='gem-install-version-ubuntu-1404'
+  - rvm: 2.3.1
     env: SUITE=test:kitchen_automate
     before_install:
     - echo -n $EC2_KEY_CHUNK_{0..24} >> ~/.ssh/kitchen-key-compliance.base64

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ The third scenario supports direct reporting to Chef Visibility. It also support
 
 The audit cookbook needs to be configured for each node where the `chef-client` runs. The `audit` cookbook can be reused for all nodes, all node-specific configuration is done via Chef attributes.
 
+### InSpec Gem Installation
+
+Beginning with version 3.x of the `audit` cookbook, the cookbook will first check to see if InSpec is already installed. If it is, it will not attempt to install it. Future releases of the Chef omnibus package are expected to include InSpec so this will reduce audit run times and also ensure that Chef users in air-gapped or firewalled environments can still use the `audit` cookbook without requiring gem mirrors, etc.
+
+Also beginning with version 3.x of the `audit` cookbook, the default version of the InSpec gem to be installed (if it isn't already installed) is the latest version. Prior versions of the `audit` cookbook were version-locked to `inspec` version 1.15.0.
+
+To install a different version of the InSpec gem, or to force installation of the gem, set the `node['audit']['inspec_version']` attribute to the version you wish to be installed.
+
 ### Upload cookbook to Chef Server
 
 The `audit` cookbook is available at [Chef Supermarket](https://supermarket.chef.io/cookbooks/audit). This allows you to reuse your existing workflow for managing cookbooks in your runlist.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 
 # controls inspec gem version to install
 # example values: '1.1.0', 'latest'
-default['audit']['inspec_version'] = '1.15.0'
+default['audit']['inspec_version'] = nil
 
 # sets URI to alternate gem source
 # example values: nil, 'https://mygem.server.com'

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -4,8 +4,13 @@
 if defined?(ChefSpec)
 
   ChefSpec.define_matcher :compliance_profile
+  ChefSpec.define_matcher :inspec_gem
 
   def upload_compliance_profile(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:compliance_upload, :upload, resource_name)
+  end
+
+  def install_inspec_gem(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:inspec_gem, :install, resource_name)
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.4.0'
+version '3.0.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'

--- a/recipes/inspec.rb
+++ b/recipes/inspec.rb
@@ -17,12 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-chef_gem 'inspec' do
-  version node['audit']['inspec_version'] if node['audit']['inspec_version'] != 'latest'
-  compile_time true
-  clear_sources true if node['audit']['inspec_gem_source']
-  source node['audit']['inspec_gem_source'] if node['audit']['inspec_gem_source']
-  action :install
-end
-
-load_inspec_libs
+inspec_gem 'inspec' do
+  version node['audit']['inspec_version']
+  source node['audit']['inspec_gem_source']
+  action :nothing
+end.run_action(:install)

--- a/resources/inspec_gem.rb
+++ b/resources/inspec_gem.rb
@@ -1,0 +1,58 @@
+provides :inspec_gem
+resource_name :inspec_gem
+
+property :gem_name, String, name_property: true
+property :version, String
+property :source, String
+
+default_action :install
+
+action :install do
+  if !version.nil?
+    converge_by 'uninstall all inspec and train gem versions' do
+      uninstall_inspec_gem
+    end
+    converge_by "install requested inspec version #{version}" do
+      install_inspec_gem(version: version, source: source)
+    end
+  elsif !inspec_installed?
+    converge_by 'install latest InSpec version' do
+      install_inspec_gem(source: source)
+    end
+  else
+    Chef::Log.info("inspec_gem: not installing InSpec. It's already installed and an explicit version was not supplied.")
+  end
+end
+
+action_class do
+  def install_inspec_gem(options)
+    gem_source  = options[:source]
+    gem_version = options[:version]
+
+    chef_gem 'inspec' do
+      version gem_version if !gem_version.nil? && gem_version != 'latest'
+      clear_sources true unless gem_source.nil?
+      source gem_source unless gem_source.nil?
+      action :install
+    end
+  end
+
+  def uninstall_inspec_gem
+    chef_gem 'remove all inspec versions' do
+      package_name 'inspec'
+      action :remove
+    end
+
+    chef_gem 'remove all train versions' do
+      package_name 'train'
+      action :remove
+    end
+  end
+
+  def inspec_installed?
+    require 'inspec'
+    true
+  rescue LoadError
+    false
+  end
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -27,7 +27,7 @@ describe 'audit::default' do
     end
 
     it 'installs the inspec gem' do
-      expect(chef_run).to install_chef_gem('inspec')
+      expect(chef_run).to install_inspec_gem('inspec')
     end
 
     it 'converges successfully' do
@@ -44,7 +44,7 @@ describe 'audit::default' do
     end
 
     it 'installs the inspec gem with the correct version' do
-      expect(chef_run).to install_chef_gem('inspec').with(version: '0.0.0')
+      expect(chef_run).to install_inspec_gem('inspec').with(version: '0.0.0')
     end
 
     it 'converges successfully' do
@@ -60,8 +60,7 @@ describe 'audit::default' do
     end
 
     it 'installs the inspec gem from the alternate source' do
-      expect(chef_run).to install_chef_gem('inspec').with(clear_sources: true)
-      expect(chef_run).to install_chef_gem('inspec').with(source: 'http://0.0.0.0:8080')
+      expect(chef_run).to install_inspec_gem('inspec').with(source: 'http://0.0.0.0:8080')
     end
 
     it 'converges successfully' do

--- a/test/cookbooks/test_helper/recipes/install_inspec_1_17.rb
+++ b/test/cookbooks/test_helper/recipes/install_inspec_1_17.rb
@@ -1,0 +1,4 @@
+chef_gem 'inspec' do
+  version '1.17.0'
+  action :nothing
+end.run_action(:install)

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -11,7 +11,7 @@ node = json('/tmp/node.json')
 
 # TODO: change once gem resource handles alternate path to `gem` command
 describe command('/opt/chef/embedded/bin/gem list --local -a -q inspec | grep \'^inspec\' | awk -F"[()]" \'{printf $2}\'') do
-  its('stdout') { should eq node.value(['audit','inspec_version']) }
+  its('stdout') { should_not be_nil }
 end
 
 command('find /opt/kitchen/cache/cookbooks/audit -type f -a -name inspec\*.json').stdout.split.each do |f|

--- a/test/integration/gem-install-version/default_spec.rb
+++ b/test/integration/gem-install-version/default_spec.rb
@@ -1,6 +1,5 @@
-#inspec (1.16.1)
-
-# verify that only inspec v1.16.1 is installed
-describe command('/opt/chef/embedded/bin/gem list --local -a -q inspec | grep \'^inspec\' | awk -F"[()]" \'{printf $2}\'') do
-  its('stdout') { should cmp '1.18.0' }
+# verify that a specific inspec version is installed
+describe gem('inspec', :chef) do
+  it { should be_installed }
+  its('version') { should cmp '1.18.0'}
 end

--- a/test/integration/gem-install-version/default_spec.rb
+++ b/test/integration/gem-install-version/default_spec.rb
@@ -1,0 +1,6 @@
+#inspec (1.16.1)
+
+# verify that only inspec v1.16.1 is installed
+describe command('/opt/chef/embedded/bin/gem list --local -a -q inspec | grep \'^inspec\' | awk -F"[()]" \'{printf $2}\'') do
+  its('stdout') { should cmp '1.18.0' }
+end


### PR DESCRIPTION
To assist with air-gapped installations, the audit cookbook is
being modified to only install InSpec if it's not already installed
or if the user has explicitly stated a version to be installed.

This will allow users to use other methods of installing the gem
in the chef gem path, or take advantage of InSpec being included
in chef client in the future.

Signed-off-by: Adam Leff <adam@leff.co>