### PR TITLE
Remove typed_attributes and leave the backend handle attributes

### DIFF
--- a/libraries/reporters/automate.rb
+++ b/libraries/reporters/automate.rb
@@ -75,34 +75,6 @@ module Reporter
       end
     end
 
-    # Some document stores like ElasticSearch don't like values that change type
-    # This function converts all profile attribute defaults to string and
-    # adds a :type key to store the original type
-    def typed_attributes(profiles)
-      return profiles unless profiles.class == Array && !profiles.empty?
-      profiles.each { |profile|
-        next unless profile[:attributes].class == Array && !profile[:attributes].empty?
-        profile[:attributes].map { |attrib|
-          case attrib[:options][:default].class.to_s
-          when 'String'
-            attrib[:options][:type] = 'string'
-          when 'FalseClass'
-            attrib[:options][:type] = 'boolean'
-            attrib[:options][:default] = attrib[:options][:default].to_s
-          when 'Fixnum'
-            attrib[:options][:type] = 'int'
-            attrib[:options][:default] = attrib[:options][:default].to_s
-          when 'Float'
-            attrib[:options][:type] = 'float'
-            attrib[:options][:default] = attrib[:options][:default].to_s
-          else
-            Chef::Log.warn "enriched_report: unsupported data type(#{attrib[:options][:default].class}) for attribute #{attrib[:options]['name']}"
-            attrib[:options][:type] = 'unknown'
-          end
-        }
-      }
-    end
-
     # ***************************************************************************************
     # TODO: We could likely simplify/remove alot of the extra logic we have here with a small
     # revamp of the Automate expected input.
@@ -113,9 +85,6 @@ module Reporter
 
       # Remove nil profiles if any
       final_report[:profiles].select! { |p| p }
-
-      # Set types for profile attributes
-      final_report[:profiles] = typed_attributes(final_report[:profiles])
 
       # Label this content as an inspec_report
       final_report[:type] = 'inspec_report'

--- a/spec/unit/libraries/automate_spec.rb
+++ b/spec/unit/libraries/automate_spec.rb
@@ -106,33 +106,4 @@ describe 'Reporter::ChefAutomate methods' do
     expect(viz2.send_report(MockData.inspec_results)).to eq(false)
   end
 
-  it 'sets the attribute types like TypeScript' do
-    profiles = [
-      {
-        "attributes":[
-          { "name":"syslog_pkg",
-            "options":{ "default":"rsyslog", "description":"a string" } },
-          { "name":"sysctl_forwarding",
-            "options":{ "default":false, "description":"a boolean" } },
-          { "name":"some_number",
-            "options":{ "default":0, "description":"a number" } },
-          { "name":"some_float",
-            "options":{ "default":0.8, "description":"a bloody float" } },
-          { "name":"some_array",
-            "options":{ "default":[], "description":"a bloody array" } }
-        ]
-      }
-    ]
-    # poor man's deep clone
-    types_profiles = profiles.dup
-    types_profiles[0][:attributes][0][:options][:type] = 'string'
-    types_profiles[0][:attributes][1][:options][:type] = 'boolean'
-    types_profiles[0][:attributes][1][:options][:default] = 'false'
-    types_profiles[0][:attributes][2][:options][:type] = 'int'
-    types_profiles[0][:attributes][2][:options][:default] = '0'
-    types_profiles[0][:attributes][3][:options][:type] = 'float'
-    types_profiles[0][:attributes][3][:options][:default] = '0.8'
-    types_profiles[0][:attributes][4][:options][:type] = 'unknown'
-    expect(@automate.typed_attributes(profiles)).to eq(types_profiles)
-  end
 end

--- a/spec/unit/libraries/automate_spec.rb
+++ b/spec/unit/libraries/automate_spec.rb
@@ -58,7 +58,7 @@ describe 'Reporter::ChefAutomate methods' do
             "id":"tmp-1.1",
             "results":[{"status":"passed", "code_desc":"File /tmp should be owned by \"root\"", "run_time":0.028845, "start_time":"2016-10-19 11:09:43 -0400"}]}],
         "groups":[{"title":"/tmp Compliance Profile", "controls":["tmp-1.0", "tmp-1.1"], "id":"controls/tmp.rb"}],
-        "attributes":[{"name":"syslog_pkg", "options":{"default":"rsyslog", "description":"syslog package...", "type":"string"}}]}],
+        "attributes":[{"name":"syslog_pkg", "options":{"default":"rsyslog", "description":"syslog package..."}}]}],
       "other_checks": [],
       "statistics":{"duration":0.032332},
       "type":"inspec_report",

--- a/spec/unit/libraries/cs_automate_spec.rb
+++ b/spec/unit/libraries/cs_automate_spec.rb
@@ -44,7 +44,7 @@ describe 'Reporter::ChefServerAutomate methods' do
             "id": "tmp-1.1",
             "results": [{"status": "passed", "code_desc": "File /tmp should be owned by \"root\"", "run_time": 0.028845, "start_time": "2016-10-19 11:09:43 -0400"}]}],
         "groups": [{"title": "/tmp Compliance Profile", "controls": ["tmp-1.0", "tmp-1.1"], "id": "controls/tmp.rb"}],
-        "attributes": [{"name": "syslog_pkg", "options": {"default": "rsyslog", "description": "syslog package...", "type": "string"}}]}],
+        "attributes": [{"name": "syslog_pkg", "options": {"default": "rsyslog", "description": "syslog package..."}}]}],
       "other_checks": [],
       "statistics":{"duration":0.032332},
       "type": "inspec_report",
@@ -69,8 +69,9 @@ describe 'Reporter::ChefServerAutomate methods' do
     # set data_collector
     stub_request(:post, 'https://chef.server/data_collector').
              with(:body => @enriched_report_expected.to_json,
-             :headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Length'=>'2706', 'Content-Type'=>'application/json', 'Host'=>/.+/, 'User-Agent'=>/.+/, 'X-Chef-Version'=>/.+/, 'X-Ops-Authorization-1'=>/.+/, 'X-Ops-Authorization-2'=>/.+/, 'X-Ops-Authorization-3'=>/.+/, 'X-Ops-Authorization-4' => /.+/, 'X-Ops-Authorization-5'=>/.+/, 'X-Ops-Authorization-6'=>/.+/, 'X-Ops-Content-Hash'=>/.+/, 'X-Ops-Server-Api-Version'=>'1', 'X-Ops-Sign'=>'algorithm=sha1;version=1.1;', 'X-Ops-Timestamp'=>/.+/, 'X-Ops-Userid'=>'spec-node', 'X-Remote-Request-Id'=>/.+/}).
+             headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Length'=>/.+/, 'Content-Type'=>'application/json', 'Host'=>/.+/, 'User-Agent'=>/.+/, 'X-Chef-Version'=>/.+/, 'X-Ops-Authorization-1'=>/.+/, 'X-Ops-Authorization-2'=>/.+/, 'X-Ops-Authorization-3'=>/.+/, 'X-Ops-Authorization-4'=>/.+/, 'X-Ops-Authorization-5'=>/.+/, 'X-Ops-Authorization-6'=>/.+/, 'X-Ops-Content-Hash'=>/.+/, 'X-Ops-Server-Api-Version'=>'1', 'X-Ops-Sign'=>'algorithm=sha1;version=1.1;', 'X-Ops-Timestamp'=>/.+/, 'X-Ops-Userid'=>'spec-node', 'X-Remote-Request-Id'=>/.+/}).           
              to_return(:status => 200, :body => "", :headers => {})
+
     @automate = Reporter::ChefServerAutomate.new(opts)
   end
 


### PR DESCRIPTION
Those types are not required with latest Automate 0.8.0