### PR TITLE
Update to use v1.27.0 Compliance::API of "inspec" gem.

### DIFF
--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -54,7 +54,7 @@ def login_to_compliance(server, user, access_token, refresh_token)
     config['server'] = server
     config['token'] = access_token
     config['insecure'] = true
-    config['version'] = Compliance::API.version( {'server' => server, 'insecure' => true } )
+    config['version'] = Compliance::API.version({ 'server' => server, 'insecure' => true })
     config.store
   else
     Chef::Log.error msg

--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -54,7 +54,7 @@ def login_to_compliance(server, user, access_token, refresh_token)
     config['server'] = server
     config['token'] = access_token
     config['insecure'] = true
-    config['version'] = Compliance::API.version(server, true)
+    config['version'] = Compliance::API.version(server)
     config.store
   else
     Chef::Log.error msg

--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -54,7 +54,7 @@ def login_to_compliance(server, user, access_token, refresh_token)
     config['server'] = server
     config['token'] = access_token
     config['insecure'] = true
-    config['version'] = Compliance::API.version({'server' => server, 'insecure' => true })
+    config['version'] = Compliance::API.version( {'server' => server, 'insecure' => true } )
     config.store
   else
     Chef::Log.error msg

--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -54,7 +54,7 @@ def login_to_compliance(server, user, access_token, refresh_token)
     config['server'] = server
     config['token'] = access_token
     config['insecure'] = true
-    config['version'] = Compliance::API.version(server)
+    config['version'] = Compliance::API.version({'server' => server, 'insecure' => true })
     config.store
   else
     Chef::Log.error msg

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.0.0'
+version '4.0.1'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'


### PR DESCRIPTION
### Description

[v1.27.0](http://www.rubydoc.info/gems/inspec/1.27.0/Compliance/API#version-class_method) of Compliance::API#version only takes one parameter, this cookbook is using the API of [v1.24.0](http://www.rubydoc.info/gems/inspec/1.24.0/Compliance/API#version-class_method) of Compliance::API#version which used to take two parameters.

Update to use v1.27.0 Compliance::API of `inspec` gem.

### Issues Resolved

#232

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing. (bug fix)
- [N/A] New functionality has been documented in the README if applicable (bug fix)
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>