### PR TITLE
Fixed typo, Reporter::ChefServer does not exist.

### DIFF
--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -238,7 +238,7 @@ class Chef
               raise_if_unreachable: raise_if_unreachable,
               source_location: source_location,
             }
-            Reporter::ChefServer.new(opts).send_report(report)
+            Reporter::ChefServerCompliance.new(opts).send_report(report)
           else
             Chef::Log.warn "unable to determine chef-server url required by inspec report collector '#{reporter}'. Skipping..."
           end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.0.0'
+version '4.0.2'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'


### PR DESCRIPTION
### Description

[Line 241](https://github.com/chef-cookbooks/audit/blob/master/files/default/handler/audit_report.rb#L241) calls `Reporter::ChefServer` however, this class doesn't exist.  

I believe this should be `Reporter::ChefServerCompliance` based on the pattern of other reporters,  that `Reporter::ChefServerCompliance` exists, and this change resolves the error on my Chef Server.

Bumped to version 4.0.2 as I submitted PREQ #235 which bumps the version to 4.0.1.

```
$ grep Reporter:: files/default/handler/audit_report.rb
          Reporter::ChefAutomate.new(opts).send_report(report)
            Reporter::ChefServerAutomate.new(opts).send_report(report)
            Reporter::ChefCompliance.new(opts).send_report(report)
            Reporter::ChefServer.new(opts).send_report(report)
          Reporter::JsonFile.new({ file: path }).send_report(report) 
```

### Issues Resolved

#234 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing. (N/A: Bug Fix)
- [x] New functionality has been documented in the README if applicable (N/A: Bugfix)
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
