### PR TITLE
Ensure min version of inspec is used

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -121,7 +121,7 @@ suites:
     attributes:
       audit:
         collector: json-file
-        inspec_version: 1.20.0
+        inspec_version: 1.29.0
         fail_if_not_present: true
   - name: skip-inspec-gem-install
     run_list:
@@ -130,5 +130,5 @@ suites:
     attributes:
       audit:
         collector: json-file
-        inspec_version: 1.19.1
+        inspec_version: 1.25.1
         fail_if_not_present: true

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -124,7 +124,13 @@ class Chef
 
       # run profiles and return report
       def call(opts, profiles)
-        Chef::Log.info "Initialize InSpec #{::Inspec::VERSION}"
+        Chef::Log.info "Using InSpec #{::Inspec::VERSION}"
+
+        if Gem::Version.new(Inspec::VERSION) < Gem::Version.new('1.24.0')
+          Chef::Log.error "This audit cookbook version requires InSpec 1.24.0 or newer, aborting compliance scan..."
+          return {}
+        end
+
         Chef::Log.debug "Options are set to: #{opts}"
         runner = ::Inspec::Runner.new(opts)
 

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -5,6 +5,8 @@ class Chef
   class Handler
     # Creates a compliance audit report
     class AuditReport < ::Chef::Handler
+      MIN_INSPEC_VERSION = '1.25.1'.freeze
+
       def report
         # get reporter(s) from attributes as an array
         reporters = get_reporters(node['audit'])
@@ -125,10 +127,8 @@ class Chef
       # run profiles and return report
       def call(opts, profiles)
         Chef::Log.info "Using InSpec #{::Inspec::VERSION}"
-
-        if Gem::Version.new(Inspec::VERSION) < Gem::Version.new('1.24.0')
-          Chef::Log.error "This audit cookbook version requires InSpec 1.24.0 or newer, aborting compliance scan..."
-          return {}
+        if Gem::Version.new(::Inspec::VERSION) < Gem::Version.new(MIN_INSPEC_VERSION)
+          raise "This audit cookbook version requires InSpec #{MIN_INSPEC_VERSION} or newer, aborting compliance scan..."
         end
 
         Chef::Log.debug "Options are set to: #{opts}"

--- a/test/integration/gem-install-version/default.rb
+++ b/test/integration/gem-install-version/default.rb
@@ -1,5 +1,5 @@
 # verify that a specific inspec version is installed
 describe gem('inspec', :chef) do
   it { should be_installed }
-  its('version') { should cmp '1.20.0'}
+  its('version') { should cmp '1.29.0'}
 end

--- a/test/integration/skip-inspec-gem-install/default.rb
+++ b/test/integration/skip-inspec-gem-install/default.rb
@@ -1,5 +1,5 @@
 # verify that a specific inspec version is installed
 describe gem('inspec', :chef) do
   it { should be_installed }
-  its('version') { should cmp '1.19.1'}
+  its('version') { should cmp '1.25.1'}
 end


### PR DESCRIPTION
With the cookbook no longer specifying an inspec_version in attributes, it's important to ensure a compatible inspec is used.

I'm tempted to bump the required version to at least `1.25.0` because of this: https://github.com/chef/inspec/pull/1816

or should I make it 1.26 or 1.27?