### PR TITLE
Fail Chef run if Audit Mode is enabled

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The "audit cookbook" and Chef's own "Audit Mode" are not compatible
+# due to global state management done by RSpec which is used by both
+# implementations. To prevent unexpected results, the audit cookbook
+# will prevent Chef from continuing if Audit Mode is not disabled.
+unless Chef::Config[:audit_mode] == :disabled
+  raise 'Audit Mode is enabled. The audit cookbook and Audit Mode' \
+    ' cannot be used at the same time. Please disable Audit Mode' \
+    ' in your client configuration.'
+end
+
 include_recipe 'audit::inspec'
 
 load_audit_handler

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -176,4 +176,20 @@ describe 'audit::default' do
       expect { chef_run }.to_not raise_error
     end
   end
+
+  context 'when audit_mode is enabled' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.5')
+      runner.node.override['audit']['collector'] = 'json-file'
+      runner.node.override['audit']['profiles'] = [
+        { 'name': 'linux', 'compliance': 'base/linux' },
+      ]
+      Chef::Config[:audit_mode] = :enabled
+      runner.converge(described_recipe)
+    end
+
+    it 'raises an exception' do
+      expect { chef_run }.to raise_error(RuntimeError)
+    end
+  end
 end


### PR DESCRIPTION
Chef's Audit Mode and InSpec (via the audit cookbook) are not compatible to be run simultaneously. This change raises an exception if the audit cookbook is attempted to be run on a node on which Chef's Audit mode is not disabled.