### PR TITLE
fix chef compliance profile handling

### DIFF
--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -25,8 +25,8 @@ def retrieve_access_token(server_url, refresh_token, insecure)
 end
 
 # used for compliance config
-def compliance_version
-  Compliance::API.version(server, insecure)
+def compliance_version(config)
+  Compliance::API.version(config)
 end
 
 # check if profile already exists on compliance server
@@ -40,7 +40,7 @@ def upload_profile(config, owner, profile_name, path)
 end
 
 # TODO: temporary, we should use a stateless approach
-# TODO: harmonize with CLI login_refreshtoken method
+# TODO: harmonize with CLI store_access_token(url, user, token, insecure)
 def login_to_compliance(server, user, access_token, refresh_token)
   if !refresh_token.nil?
     success, msg, access_token = Compliance::API.get_token_via_refresh_token(server, refresh_token, true)
@@ -50,11 +50,13 @@ def login_to_compliance(server, user, access_token, refresh_token)
 
   if success
     config = Compliance::Configuration.new
-    config['user'] = user
+    config.clean
     config['server'] = server
-    config['token'] = access_token
     config['insecure'] = true
-    config['version'] = Compliance::API.version({ 'server' => server, 'insecure' => true })
+    config['user'] = user
+    config['token'] = access_token
+    config['server_type'] = 'compliance'
+    config['version'] = Compliance::API.version(config)
     config.store
   else
     Chef::Log.error msg

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '4.0.0'
+version '4.1.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'

--- a/resources/compliance_upload.rb
+++ b/resources/compliance_upload.rb
@@ -34,7 +34,7 @@ action :upload do
     config['token'] = access_token
     config['insecure'] = insecure
     config['server'] = server
-    config['version'] = compliance_version
+    config['version'] = compliance_version(config)
     if check_existence(config, "#{profile_name}/#{path}") && !overwrite
       Chef::Log.error 'Profile exists on the server, use property `overwrite`'
     else


### PR DESCRIPTION
### Description

Version 4 was not able to fetch profiles and report back to Chef Compliance. This PR fixes this.

This raises the general issue that we need to work even harder to consolidate the implementations between audit cookbook and inspec. This is tracked in #242