### PR TITLE
Make json-file reporter save JSON content

### DIFF
--- a/libraries/reporters/json_file.rb
+++ b/libraries/reporters/json_file.rb
@@ -16,7 +16,7 @@ module Reporter
 
     def write_to_file(report, path)
       json_file = File.new(path, 'w')
-      json_file.puts(report)
+      json_file.puts(JSON.generate(report))
       json_file.close
     end
   end


### PR DESCRIPTION
Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>

### Description

Make json-file reporter save JSON content instead of a ruby hash.

### Issues Resolved

Fixes issue https://github.com/chef-cookbooks/audit/issues/244