### PR TITLE
Raise exception if no token is set when using the chef-automate fetcher

### DIFF
--- a/files/default/vendor/chef-automate/fetcher.rb
+++ b/files/default/vendor/chef-automate/fetcher.rb
@@ -28,6 +28,12 @@ module ChefAutomate
         url = URI(dc[:server_url])
         url.path = profile_path
         profile_fetch_url = url.to_s
+
+        raise 'No data-collector token set, which is required by the chef-automate fetcher. ' \
+          'Set the `data_collector.token` configuration parameter in your client.rb ' \
+          'or use the "chef-server-automate" reporter which does not require any ' \
+          'data-collector settings and uses Chef Server to fetch profiles.' if dc[:token].nil?
+
         config = {
           'token' => dc[:token],
         }


### PR DESCRIPTION
The chef-automate fetcher uses the data_collector token settings but does not check to ensure it's set before passing it to InSpec for Fetcher purposes. This causes InSpec to create a data-collector-token header with a nil value, and then Net::HTTP will toss an ugly error when trying to call `#strip` on nil.

InSpec should validate inputs too, but this will help catch this issue in the audit cookbook and provide a better error message. This was found in the Chef sales demo environments.