### PR TITLE
Non-null header value required for using chef-automate fetcher (#258)

### DIFF
--- a/files/default/vendor/chef-automate/fetcher.rb
+++ b/files/default/vendor/chef-automate/fetcher.rb
@@ -61,7 +61,7 @@ module ChefAutomate
         'token' => opts['token'],
         'server_type' => 'automate',
         'automate' => {
-          'ent' => '',
+          'ent' => 'default',
           'token_type' => 'dctoken',
         },
       }


### PR DESCRIPTION
Signed-off-by: Nick Rycar <rycar@chef.io>

### Description

While specifying a workflow enterprise is not required to fetch compliance profiles from Chef Automate, inspec's validations do require that the associated header have a non-null value. Have updated the associated fetcher to seed the arbitrary value "default" into the enterprise header, and confirmed this produces the expected results in my local testing environment.

### Issues Resolved

Fixes #258

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A ] New functionality includes testing.
- [N/A ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
