### PR TITLE
Support for attributes within audit cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,8 @@ transport:
 
 provisioner:
   name: dokken
+  chef_log_level: info
+  chef_output_format: minimal
 
 verifier:
   name: inspec
@@ -77,11 +79,12 @@ suites:
           - name: ssh-hardening
             url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip
           - git: https://github.com/dev-sec/tests-ssh-hardening.git
-          - name: ssh
-            supermarket: hardening/ssh-hardening
+          - name: ssh-baseline
+            supermarket: dev-sec/ssh-baseline
   # default setting does not fail for missing profile
   - name: attributes-work
     run_list:
+      - recipe[test_helper::setup]
       - recipe[test_helper::create_file]
       - recipe[audit::default]
     attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -72,7 +72,7 @@ suites:
       - recipe[audit::default]
     attributes:
       audit:
-        collector: json-file
+        reporter: json-file
         profiles:
           - name: ssh-hardening
             url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip
@@ -86,10 +86,9 @@ suites:
       - recipe[audit::default]
     attributes:
       audit:
-        collector: json-file
+        reporter: json-file
         profiles:
-          - name: attribute-file-exists
-            git: https://github.com/mhedgpeth/attribute-file-exists-profile.git
+          - git: https://github.com/mhedgpeth/attribute-file-exists-profile.git
         attributes:
           file: /opt/kitchen/cache/attribute-file-exists.test
   - name: missing-profile-no-fail
@@ -98,7 +97,7 @@ suites:
       - recipe[audit::default]
     attributes:
       audit:
-        collector: json-file
+        reporter: json-file
         profiles:
           - name: ssh-hardening
             url: https://github.com/dev-sec/this-is-not-available.zip
@@ -110,7 +109,7 @@ suites:
       - recipe[audit::default]
     attributes:
       audit:
-        collector: json-file
+        reporter: json-file
         fail_if_not_present: true
         profiles:
           - name: ssh-hardening
@@ -132,7 +131,7 @@ suites:
       - recipe[audit::default]
     attributes:
       audit:
-        collector: json-file
+        reporter: json-file
         inspec_version: 1.29.0
         fail_if_not_present: true
   - name: skip-inspec-gem-install
@@ -141,7 +140,7 @@ suites:
       - recipe[audit::default]
     attributes:
       audit:
-        collector: json-file
+        reporter: json-file
         inspec_version: 1.25.1
         fail_if_not_present: true
   - name: chef-12-test
@@ -149,6 +148,6 @@ suites:
       - recipe[audit::default]
     attributes:
       audit:
-        collector: json-file
+        reporter: json-file
         inspec_version: 1.25.1
         fail_if_not_present: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -80,6 +80,18 @@ suites:
           - name: ssh
             supermarket: hardening/ssh-hardening
   # default setting does not fail for missing profile
+  - name: attributes-work
+    run_list:
+      - recipe[test_helper::create_file]
+      - recipe[audit::default]
+    attributes:
+      audit:
+        collector: json-file
+        profiles:
+          - name: attribute-file-exists
+            git: https://github.com/mhedgpeth/attribute-file-exists-profile.git
+        attributes:
+          file: /opt/kitchen/cache/attribute-file-exists.test
   - name: missing-profile-no-fail
     run_list:
       - recipe[test_helper::setup]

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ group :test do
   gem 'rb-readline'
   gem 'webmock'
   gem 'fauxhai', '~> 5.2'
+  gem 'pry-remote'
+  gem 'pry-nav'
 end
 
 group :integration do

--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,6 @@ group :test do
   gem 'rb-readline'
   gem 'webmock'
   gem 'fauxhai', '~> 5.2'
-  gem 'pry-remote'
-  gem 'pry-nav'
 end
 
 group :integration do

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ default["audit"] = {
 }
 ```
 
+#### Attributes
+
+You can also pass in [InSpec Attributes](http://www.anniehedgie.com/inspec-basics-10) to your audit run. You do this by defining the attributes here:
+
+```ruby
+default['audit']['attributes'] = {
+  first_attribute: 'some vaule',
+  second_attribute: 'another value',
+}
+```
+
 ### Reporting
 
 #### Reporting to Chef Automate via Chef Server

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ default["audit"] = {
 
 #### Attributes
 
-You can also pass in [InSpec Attributes](http://www.anniehedgie.com/inspec-basics-10) to your audit run. You do this by defining the attributes here:
+You can also pass in [InSpec Attributes](https://www.inspec.io/docs/reference/profiles/) to your audit run. You do this by defining the attributes here:
 
 ```ruby
 default['audit']['attributes'] = {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -84,4 +84,4 @@ default['audit']['overwrite'] = true
 default['audit']['profiles'] = []
 
 # Attributes used to run the given profiles
-default['audit']['attributes'] = { }
+default['audit']['attributes'] = {}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -82,3 +82,6 @@ default['audit']['overwrite'] = true
 # Chef Inspec Compliance profiles to be used for scan of node
 # See README.md for details
 default['audit']['profiles'] = []
+
+# Attributes used to run the given profiles
+default['audit']['attributes'] = { }

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -121,7 +121,7 @@ class Chef
           'format' => format,
           'output' => output,
           'logger' => Chef::Log, # Use chef-client log level for inspec run,
-          'attributes' => attributes,
+          attributes: attributes,
         }
         opts
       end

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -30,6 +30,7 @@ class Chef
         profiles = node['audit']['profiles']
         quiet = node['audit']['quiet']
         fetcher = node['audit']['fetcher']
+        attributes = node['audit']['attributes']
 
         # load inspec, supermarket bundle and compliance bundle
         load_needed_dependencies
@@ -53,7 +54,7 @@ class Chef
           create_timestamp_file if interval_enabled
 
           # return hash of opts to be used by runner
-          opts = get_opts('json', quiet)
+          opts = get_opts('json', quiet, attributes)
 
           # instantiate inspec runner with given options and run profiles; return report
           report = call(opts, profiles)
@@ -112,15 +113,15 @@ class Chef
       end
 
       # sets format to json-min when chef-compliance, json when chef-automate
-      def get_opts(format, quiet)
+      def get_opts(format, quiet, attributes)
         output = quiet ? ::File::NULL : $stdout
         Chef::Log.warn "Format is #{format}"
         opts = {
           'report' => true,
           'format' => format,
           'output' => output,
-          'logger' => Chef::Log, # Use chef-client log level for inspec run
-          'attributes' => node['audit']['attributes'],
+          'logger' => Chef::Log, # Use chef-client log level for inspec run,
+          'attributes' => attributes,
         }
         opts
       end

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -120,6 +120,7 @@ class Chef
           'format' => format,
           'output' => output,
           'logger' => Chef::Log, # Use chef-client log level for inspec run
+          'attributes' => node['audit']['attributes'],
         }
         opts
       end

--- a/spec/unit/report/audit_report_spec.rb
+++ b/spec/unit/report/audit_report_spec.rb
@@ -66,7 +66,7 @@ describe 'Chef::Handler::AuditReport methods' do
       expect(opts['format']).to eq('json-min')
       expect(opts['output']).to eq('/dev/null')
       expect(opts['logger']).to eq(Chef::Log)
-      expect(opts['attributes'].empty?).to be true
+      expect(opts[:attributes].empty?).to be true
     end
     it 'sets the format to json-min' do
       format = 'json'
@@ -76,7 +76,7 @@ describe 'Chef::Handler::AuditReport methods' do
       expect(opts['format']).to eq('json')
       expect(opts['output']).to eq('/dev/null')
       expect(opts['logger']).to eq(Chef::Log)
-      expect(opts['attributes'].empty?).to be true
+      expect(opts[:attributes].empty?).to be true
     end
     it 'sets the attributes' do
       format = 'json-min'
@@ -86,8 +86,8 @@ describe 'Chef::Handler::AuditReport methods' do
         second: 'value2'
       }
       opts = @audit_report.get_opts(format, quiet, attributes)
-      expect(opts['attributes'][:first]).to eq('value1')
-      expect(opts['attributes'][:second]).to eq('value2')
+      expect(opts[:attributes][:first]).to eq('value1')
+      expect(opts[:attributes][:second]).to eq('value2')
     end
   end
 

--- a/spec/unit/report/audit_report_spec.rb
+++ b/spec/unit/report/audit_report_spec.rb
@@ -61,14 +61,33 @@ describe 'Chef::Handler::AuditReport methods' do
     it 'sets the format to json-min' do
       format = 'json-min'
       quiet = true
-      opts = @audit_report.get_opts(format, quiet)
-      expect(opts).to eq({'report' => true, 'format' => 'json-min', 'output' => '/dev/null', 'logger' => Chef::Log})
+      opts = @audit_report.get_opts(format, quiet, {})
+      expect(opts['report']).to be true
+      expect(opts['format']).to eq('json-min')
+      expect(opts['output']).to eq('/dev/null')
+      expect(opts['logger']).to eq(Chef::Log)
+      expect(opts['attributes'].empty?).to be true
     end
     it 'sets the format to json-min' do
       format = 'json'
       quiet = true
-      opts = @audit_report.get_opts(format, quiet)
-      expect(opts).to eq({'report' => true, 'format' => 'json', 'output' => '/dev/null', 'logger' => Chef::Log})
+      opts = @audit_report.get_opts(format, quiet, {})
+      expect(opts['report']).to be true
+      expect(opts['format']).to eq('json')
+      expect(opts['output']).to eq('/dev/null')
+      expect(opts['logger']).to eq(Chef::Log)
+      expect(opts['attributes'].empty?).to be true
+    end
+    it 'sets the attributes' do
+      format = 'json-min'
+      quiet = true
+      attributes = {
+        first: 'value1',
+        second: 'value2'
+      }
+      opts = @audit_report.get_opts(format, quiet, attributes)
+      expect(opts['attributes'][:first]).to eq('value1')
+      expect(opts['attributes'][:second]).to eq('value2')
     end
   end
 

--- a/test/cookbooks/test_helper/recipes/create_file.rb
+++ b/test/cookbooks/test_helper/recipes/create_file.rb
@@ -1,0 +1,5 @@
+# ensures that the file defined by attributes exists, so its associated profile will pass
+
+file node['audit']['attributes']['file'] do
+  action :create
+end

--- a/test/cookbooks/test_helper/recipes/setup.rb
+++ b/test/cookbooks/test_helper/recipes/setup.rb
@@ -11,4 +11,5 @@ include_recipe 'git::default'
 output=Chef::JSONCompat.to_json_pretty(node.to_hash).to_s
 file '/tmp/node.json' do
   content output
+  sensitive true
 end

--- a/test/integration/attributes-work/default.rb
+++ b/test/integration/attributes-work/default.rb
@@ -1,0 +1,1 @@
+# will put a test that makes sure a file is there


### PR DESCRIPTION
Fixes #261 

Allows for `node['audit']['attributes']` to define which attributes are passed into the InSpec run
Added documentation in `README.md`
Tested in kitchen, which relies on the [attributes-file-exists-profile](https://github.com/mhedgpeth/attribute-file-exists-profile) for testing that a file exists, driven off of an attribute.

@jeremymv2 this is what we were talking about as a better way to manage the "profile that rules them all" pattern.