### PR TITLE
Change Inspec gem resource action from install to upgrade

### DIFF
--- a/recipes/inspec.rb
+++ b/recipes/inspec.rb
@@ -21,4 +21,4 @@ inspec_gem 'inspec' do
   version node['audit']['inspec_version']
   source node['audit']['inspec_gem_source']
   action :nothing
-end.run_action(:install)
+end.run_action(:upgrade)


### PR DESCRIPTION
### Description

Changes Inspec gem resource action from `install` to `upgrade`. This allows users to easily reach Inspec version parity on nodes that have an older, incompatible version already installed. 

In other words, the `install` action will not make a change to an existing node's Inspec version which causes the audit to fail, citing a version that is too old. This does not match with the README:
> To install a different version of the InSpec gem, or to force installation of the gem, set the `node['audit']['inspec_version']` attribute to the version you wish to be installed.

### Issues Resolved

n/a

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
