### PR TITLE
Disable default source when using user-supplied gem source

### DIFF
--- a/resources/inspec_gem.rb
+++ b/resources/inspec_gem.rb
@@ -42,8 +42,11 @@ action_class do
 
     chef_gem 'inspec' do
       version gem_version if !gem_version.nil? && gem_version != 'latest'
-      clear_sources true unless gem_source.nil?
-      source gem_source unless gem_source.nil?
+      unless gem_source.nil?
+        clear_sources true
+        include_default_source false
+        source gem_source
+      end
       action :install
     end
   end

--- a/resources/inspec_gem.rb
+++ b/resources/inspec_gem.rb
@@ -44,7 +44,7 @@ action_class do
       version gem_version if !gem_version.nil? && gem_version != 'latest'
       unless gem_source.nil?
         clear_sources true
-        include_default_source false
+        include_default_source false if respond_to?(:include_default_source)
         source gem_source
       end
       action :install


### PR DESCRIPTION
The `clear_sources` property does not remove the default gem source when the RubyGems package provider does its work. We need to also set the `include_default_source` property to false to ensure users' requesting gem source is the only gem source used (instead of rubygems.org, for example).