### PR TITLE
Add json-file location to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,14 @@ audit: {
 }
 ```
 
+The resulting file will be written to `<chef_cache_path>/cookbooks/audit/inspec-<YYYYMMDDHHMMSS>.json`. The path will also be output to the Chef log:
+
+```
+[2017-08-29T00:22:10+00:00] INFO: Reporting to json-file
+[2017-08-29T00:22:10+00:00] INFO: Writing report to /opt/kitchen/cache/cookbooks/audit/inspec-20170829002210.json
+[2017-08-29T00:22:10+00:00] INFO: Report handlers complete
+```
+
 #### Multiple Reporters
 
 To enable multiple reporters, simply define multiple reporters with all the necessary information

--- a/test/integration/default/default.rb
+++ b/test/integration/default/default.rb
@@ -16,7 +16,6 @@ end
 
 command('find /opt/kitchen/cache/cookbooks/audit -type f -a -name inspec\*.json').stdout.split.each do |f|
   describe json(f.to_s) do
-    its('version') { should eq node.value(['audit','inspec_version']) }
     its(['statistics','duration']) { should be < 10 }
   end
 end


### PR DESCRIPTION
Add the location of the json-file output to the README so people don't
have to go a-huntin' through the code to find the location.

Also fix a test that's failing in Travis due to the InSpec version being embedded in Chef omnibus since Chef 13.

Fixes #269