### PR TITLE
Pass Chef node to InSpec as an attribute

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -91,6 +91,7 @@ suites:
         reporter: json-file
         profiles:
           - git: https://github.com/mhedgpeth/attribute-file-exists-profile.git
+          - git: https://github.com/adamleff/inspec-profile-chef-node-attributes.git
         attributes:
           file: /opt/kitchen/cache/attribute-file-exists.test
   - name: missing-profile-no-fail

--- a/README.md
+++ b/README.md
@@ -473,6 +473,31 @@ default['audit']['inspec_gem_source'] = 'http://internal.gem.server.com/gems'
 
 Please note that all dependencies to the `inspec` gem must also be hosted in this location.
 
+## Using Chef node data
+
+While it is recommended that InSpec profiles should be self-contained and not rely on external data unless
+necessary, there are valid use cases where a profile's test may exhibit different behavior depending on
+aspects of the node under test.
+
+To assist with these use cases, the audit cookbook will pass the Chef node object as an InSpec attribute
+named `chef_node`. This will provide the ability to write more flexible profiles:
+
+```ruby
+chef_node = attribute('chef_node', description: 'Chef Node', default: {})
+
+control 'no-password-auth-in-prod' do
+  title 'No Password Authentication in Production'
+  desc 'Password authentication is allowed in all environments except production'
+  impact 1.0
+
+  describe sshd_config do
+    its('PasswordAuthentication') { should cmp 'No' }
+  end
+
+  only_if { chef_node['chef_environment'] == 'production' }
+end
+```
+
 ## Troubleshooting
 
 Please refer to TROUBLESHOOTING.md.

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -30,7 +30,10 @@ class Chef
         profiles = node['audit']['profiles']
         quiet = node['audit']['quiet']
         fetcher = node['audit']['fetcher']
-        attributes = node['audit']['attributes']
+        attributes = node['audit']['attributes'].to_h
+
+        # add chef node data as an attribute
+        attributes['chef_node'] = chef_node_attribute_data
 
         # load inspec, supermarket bundle and compliance bundle
         load_needed_dependencies
@@ -259,6 +262,14 @@ class Chef
         else
           Chef::Log.warn "#{reporter} is not a supported InSpec report collector"
         end
+      end
+
+      # Gather Chef node attributes, etc. for passing to the InSpec run
+      def chef_node_attribute_data
+        node_data = node.to_h
+        node_data['chef_environment'] = node.chef_environment
+
+        node_data
       end
     end
   end

--- a/test/integration/inspec-attributes/default.rb
+++ b/test/integration/inspec-attributes/default.rb
@@ -11,3 +11,22 @@ describe 'attribute control' do
     expect(attribute_control['status']).to eq('passed')
   end
 end
+
+# Test ability to read in Chef node attributes
+cpu_key_control = controls.find { |x| x['code_desc'] == 'Chef node data - cpu key should exist'}
+cpu_key_control = {} if cpu_key_control.nil?
+
+describe 'cpu_key control' do
+  it 'status should be passed' do
+    expect(cpu_key_control['status']).to eq('passed')
+  end
+end
+
+chef_environment_control = controls.find { |x| x['code_desc'] == 'Chef node data - chef_environment should exist'}
+chef_environment_control = {} if chef_environment_control.nil?
+
+describe 'chef_environment control' do
+  it 'status should be passed' do
+    expect(chef_environment_control['status']).to eq('passed')
+  end
+end


### PR DESCRIPTION
Providing the Chef node object (attributes, environment, etc.) to InSpec as an attribute will allow the ability to write more flexible profiles and eliminate the need for users to write out JSON files during the converge phase only to get read in by the profile later.

Fixes #268