### PR TITLE
Make chef_node attribute an opt-in feature

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -91,9 +91,25 @@ suites:
         reporter: json-file
         profiles:
           - git: https://github.com/mhedgpeth/attribute-file-exists-profile.git
-          - git: https://github.com/adamleff/inspec-profile-chef-node-attributes.git
         attributes:
           file: /opt/kitchen/cache/attribute-file-exists.test
+  - name: chef-node-enabled
+    run_list:
+      - recipe[audit::default]
+    attributes:
+      audit:
+        reporter: json-file
+        profiles:
+          - url: https://github.com/adamleff/inspec-profile-chef-node-attributes/archive/master.tar.gz
+        chef_node_attribute_enabled: true
+  - name: chef-node-disabled
+    run_list:
+      - recipe[audit::default]
+    attributes:
+      audit:
+        reporter: json-file
+        profiles:
+          - url: https://github.com/adamleff/inspec-profile-chef-node-attributes/archive/master.tar.gz
   - name: missing-profile-no-fail
     run_list:
       - recipe[test_helper::setup]

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,9 @@ matrix:
   - rvm: 2.3.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='inspec-attributes-ubuntu-1404'
+  - rvm: 2.3.3
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='chef-node-enabled-ubuntu-1404'
+  - rvm: 2.3.3
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='chef-node-disabled-ubuntu-1404'

--- a/README.md
+++ b/README.md
@@ -532,6 +532,14 @@ While this provides the ability to write more flexible profiles, it makes it mor
 outside of an audit cookbook run, requiring the profile user to know how to pass in a single attribute containing
 Chef-like data. Therefore, it is recommended to use Option 1 whenever possible.
 
+To use this option, first enable it in a wrapper cookbook or similar:
+
+```ruby
+node.override['audit']['chef_node_attribute_enabled'] = true
+```
+
+... and then use it in your profile:
+
 ```ruby
 chef_node = attribute('chef_node', description: 'Chef Node', default: {})
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -85,3 +85,7 @@ default['audit']['profiles'] = []
 
 # Attributes used to run the given profiles
 default['audit']['attributes'] = {}
+
+# If enabled, a hash of the Chef "node" object will be sent to InSpec in an attribute
+# named `chef_node`
+default['audit']['chef_node_attribute_enabled'] = false

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -32,8 +32,8 @@ class Chef
         fetcher = node['audit']['fetcher']
         attributes = node['audit']['attributes'].to_h
 
-        # add chef node data as an attribute
-        attributes['chef_node'] = chef_node_attribute_data
+        # add chef node data as an attribute if enabled
+        attributes['chef_node'] = chef_node_attribute_data if node['audit']['chef_node_attribute_enabled']
 
         # load inspec, supermarket bundle and compliance bundle
         load_needed_dependencies

--- a/test/integration/chef-node-disabled/default.rb
+++ b/test/integration/chef-node-disabled/default.rb
@@ -1,0 +1,22 @@
+# get most recent json-file output
+json_file = command('ls -t /opt/kitchen/cache/cookbooks/audit/inspec-*.json').stdout.lines.first.chomp
+controls = json(json_file).controls
+
+# the controls that read from chef_node should fail because the chef_node data should not be present
+cpu_key_control = controls.find { |x| x['code_desc'] == 'Chef node data - cpu key should exist'}
+cpu_key_control = {} if cpu_key_control.nil?
+
+describe 'cpu_key control' do
+  it 'status should be failed' do
+    expect(cpu_key_control['status']).to eq('failed')
+  end
+end
+
+chef_environment_control = controls.find { |x| x['code_desc'] == 'Chef node data - chef_environment should exist'}
+chef_environment_control = {} if chef_environment_control.nil?
+
+describe 'chef_environment control' do
+  it 'status should be failed' do
+    expect(chef_environment_control['status']).to eq('failed')
+  end
+end

--- a/test/integration/chef-node-enabled/default.rb
+++ b/test/integration/chef-node-enabled/default.rb
@@ -1,0 +1,22 @@
+# get most recent json-file output
+json_file = command('ls -t /opt/kitchen/cache/cookbooks/audit/inspec-*.json').stdout.lines.first.chomp
+controls = json(json_file).controls
+
+# Test ability to read in Chef node attributes when the chef_node attribute is enabled
+cpu_key_control = controls.find { |x| x['code_desc'] == 'Chef node data - cpu key should exist'}
+cpu_key_control = {} if cpu_key_control.nil?
+
+describe 'cpu_key control' do
+  it 'status should be passed' do
+    expect(cpu_key_control['status']).to eq('passed')
+  end
+end
+
+chef_environment_control = controls.find { |x| x['code_desc'] == 'Chef node data - chef_environment should exist'}
+chef_environment_control = {} if chef_environment_control.nil?
+
+describe 'chef_environment control' do
+  it 'status should be passed' do
+    expect(chef_environment_control['status']).to eq('passed')
+  end
+end

--- a/test/integration/inspec-attributes/default.rb
+++ b/test/integration/inspec-attributes/default.rb
@@ -11,22 +11,3 @@ describe 'attribute control' do
     expect(attribute_control['status']).to eq('passed')
   end
 end
-
-# Test ability to read in Chef node attributes
-cpu_key_control = controls.find { |x| x['code_desc'] == 'Chef node data - cpu key should exist'}
-cpu_key_control = {} if cpu_key_control.nil?
-
-describe 'cpu_key control' do
-  it 'status should be passed' do
-    expect(cpu_key_control['status']).to eq('passed')
-  end
-end
-
-chef_environment_control = controls.find { |x| x['code_desc'] == 'Chef node data - chef_environment should exist'}
-chef_environment_control = {} if chef_environment_control.nil?
-
-describe 'chef_environment control' do
-  it 'status should be passed' do
-    expect(chef_environment_control['status']).to eq('passed')
-  end
-end


### PR DESCRIPTION
To encourage good practices, and to not send data to the InSpec runner that is not needed by most users, the `chef_node` attribute that contains the Chef node object hash will only be sent if the "chef_node_attribute_enabled" audit attribute is set to `true`