### PR TITLE
Fix Chef deprecation warnings in inspec_gem resource

### DIFF
--- a/libraries/compliance.rb
+++ b/libraries/compliance.rb
@@ -7,7 +7,7 @@ def load_inspec_libs
     Chef::Log.warn "Wrong version of inspec (#{Inspec::VERSION}), please "\
       'remove old versions (/opt/chef/embedded/bin/gem uninstall inspec).'
   else
-    Chef::Log.warn "Using inspec version: (#{Inspec::VERSION})"
+    Chef::Log.info "Using inspec version: (#{Inspec::VERSION})"
   end
   require 'bundles/inspec-compliance/api'
   require 'bundles/inspec-compliance/http'

--- a/libraries/reporters/automate.rb
+++ b/libraries/reporters/automate.rb
@@ -59,7 +59,7 @@ module Reporter
         end
 
         begin
-          Chef::Log.warn "Report to Chef Automate: #{@url}"
+          Chef::Log.info "Report to Chef Automate: #{@url}"
           Chef::Log.debug "Audit Report: #{json_report}"
           http = Chef::HTTP.new(@url)
           http.post(nil, json_report, headers)

--- a/resources/inspec_gem.rb
+++ b/resources/inspec_gem.rb
@@ -9,13 +9,13 @@ default_action :install
 
 action :install do
   # detect if installation is required
-  installation_required = inspec_info.nil? || !version.nil?
+  installation_required = inspec_info.nil? || !new_resource.version.nil?
 
   # detect if the same version is already installed
   if !inspec_info.nil?
     installed_version = inspec_info.version.to_s
     Chef::Log.debug("Installed InSpec version: #{installed_version}")
-    installation_required = false if version == installed_version
+    installation_required = false if new_resource.version == installed_version
   end
   Chef::Log.info("Installation of InSpec required: #{installation_required}")
 


### PR DESCRIPTION
The inspec_gem resource was triggering namespace collision deprecation warnings. This commit fixes those and also fixes an incorrect log severity level.