### PR TITLE
Handle '@' in username when grabbing compliance profiles

### DIFF
--- a/files/default/vendor/chef-server/fetcher.rb
+++ b/files/default/vendor/chef-server/fetcher.rb
@@ -30,7 +30,12 @@ module ChefServer
 
       return nil if uri.nil?
 
-      profile = uri.host + uri.path
+      if uri.user
+        profile = uri.user + '@' + uri.host + uri.path
+      else
+        profile = uri.host + uri.path
+      end
+
       config = {
         'insecure' => true,
       }


### PR DESCRIPTION
Signed-off-by: Kevin Reedy<kreedy@chef.io>

### Description

When an Automate user has an `@` in their username (like in LDAP or SAML), the profile URL to fetch is incorrect. It is currently resolving to `https://chefserver.example.com/compliance/organizations/acme/owners/example.com/compliance/cis-windows2012r2-level1-memberserver/tar` instead of `https://chefserver.example.com/compliance/organizations/acme/owners/First.Last@example.com/compliance/cis-windows2012r2-level1-memberserver/tar` for example.

I went to add new tests, but am confused by the current ones in https://github.com/chef-cookbooks/audit/blob/master/spec/unit/report/fetcher_spec.rb#L33-L37. I'd love to pair with someone Wednesday or early next week on the tests.

### Issues Resolved

https://getchef.zendesk.com/agent/tickets/16346
https://chefio.atlassian.net/browse/TRI-549
https://chefio.atlassian.net/browse/BUG-439

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
