### PR TITLE
Enable Inspec caching

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,10 @@ default['audit']['inspec_version'] = nil
 # notes: the root of the URL must host the *specs.4.8.gz source index
 default['audit']['inspec_gem_source'] = nil
 
+# If enabled, a cache is built for all backend calls. This should only be
+# disabled if you are expecting unique results from the same backend call.
+default['audit']['inspec_backend_cache'] = true
+
 # controls where inspec scan reports are sent
 # possible values: 'chef-server-automate', 'chef-server-compliance', 'chef-compliance', 'chef-automate', 'json-file'
 # notes: 'chef-automate' requires inspec version 0.27.1 or greater

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -38,6 +38,11 @@ class Chef
         # load inspec, supermarket bundle and compliance bundle
         load_needed_dependencies
 
+        # check if we have a valid version for backend caching
+        if node['audit']['inspec_backend_cache'] && (Gem::Version.new(::Inspec::VERSION) < Gem::Version.new('1.47.0'))
+          Chef::Log.warn 'inspec_backend_cache requires Inspec version >= 1.47.0'
+        end
+
         # detect if we run in a chef client with chef server
         load_chef_fetcher if reporters.include?('chef-server') ||
                              reporters.include?('chef-server-compliance') ||
@@ -124,6 +129,7 @@ class Chef
           'format' => format,
           'output' => output,
           'logger' => Chef::Log, # Use chef-client log level for inspec run,
+          :backend_cache => node['audit']['inspec_backend_cache'],
           attributes: attributes,
         }
         opts

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '5.0.4'
+version '6.0.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'

--- a/spec/unit/report/audit_report_spec.rb
+++ b/spec/unit/report/audit_report_spec.rb
@@ -58,6 +58,13 @@ describe 'Chef::Handler::AuditReport methods' do
   end
 
   describe 'get_opts method' do
+    let(:mynode) { Chef::Node.new }
+
+    before :each do
+      mynode.default['audit']['inspec_backend_cache'] = true
+      allow(@audit_report).to receive(:node).and_return(mynode)
+    end
+
     it 'sets the format to json-min' do
       format = 'json-min'
       quiet = true
@@ -66,6 +73,7 @@ describe 'Chef::Handler::AuditReport methods' do
       expect(opts['format']).to eq('json-min')
       expect(opts['output']).to eq('/dev/null')
       expect(opts['logger']).to eq(Chef::Log)
+      expect(opts[:backend_cache]).to be true
       expect(opts[:attributes].empty?).to be true
     end
     it 'sets the format to json-min' do
@@ -76,6 +84,7 @@ describe 'Chef::Handler::AuditReport methods' do
       expect(opts['format']).to eq('json')
       expect(opts['output']).to eq('/dev/null')
       expect(opts['logger']).to eq(Chef::Log)
+      expect(opts[:backend_cache]).to be true
       expect(opts[:attributes].empty?).to be true
     end
     it 'sets the attributes' do

--- a/spec/unit/report/audit_report_spec.rb
+++ b/spec/unit/report/audit_report_spec.rb
@@ -24,8 +24,15 @@ require_relative '../../../files/default/handler/audit_report'
 require_relative '../../data/mock.rb'
 
 describe 'Chef::Handler::AuditReport methods' do
+  let(:mynode) { Chef::Node.new }
+
+  def set_inspec_backend_cache(status = false)
+    mynode.default['audit']['inspec_backend_cache'] = status
+    allow(@audit_report).to receive(:node).and_return(mynode)
+  end
+
   before :each do
-    @audit_report = Chef::Handler::AuditReport.new()
+    @audit_report = Chef::Handler::AuditReport.new
   end
 
   describe ReportHelpers do
@@ -57,17 +64,38 @@ describe 'Chef::Handler::AuditReport methods' do
     end
   end
 
-  describe 'get_opts method' do
-    let(:mynode) { Chef::Node.new }
-
+  describe 'validate_inspec_version method' do
     before :each do
-      mynode.default['audit']['inspec_backend_cache'] = true
-      allow(@audit_report).to receive(:node).and_return(mynode)
+      require 'inspec'
     end
 
+    it 'inspec min version fail' do
+      stub_const("Inspec::VERSION", '1.20.0')
+      expect { @audit_report.validate_inspec_version }.
+        to raise_error(RuntimeError).
+        with_message('This audit cookbook version requires InSpec 1.25.1 or newer, aborting compliance scan...')
+    end
+    it 'inspec version warn for backend_cache' do
+      stub_const("Inspec::VERSION", '1.46.0')
+      set_inspec_backend_cache(true)
+      expect(Chef::Log).to receive(:warn).
+        with('inspec_backend_cache requires InSpec version >= 1.47.0').
+        and_return('captured')
+      expect(@audit_report.validate_inspec_version).to eq('captured')
+    end
+    it 'inspec version passes all requirements' do
+      stub_const("Inspec::VERSION", '1.47.0')
+      set_inspec_backend_cache(true)
+      expect(Chef::Log).to_not receive(:warn)
+      expect { @audit_report.validate_inspec_version }.to_not raise_error
+    end
+  end
+
+  describe 'get_opts method' do
     it 'sets the format to json-min' do
       format = 'json-min'
       quiet = true
+      set_inspec_backend_cache(true)
       opts = @audit_report.get_opts(format, quiet, {})
       expect(opts['report']).to be true
       expect(opts['format']).to eq('json-min')
@@ -76,15 +104,28 @@ describe 'Chef::Handler::AuditReport methods' do
       expect(opts[:backend_cache]).to be true
       expect(opts[:attributes].empty?).to be true
     end
-    it 'sets the format to json-min' do
+    it 'sets the format to json' do
       format = 'json'
       quiet = true
+      set_inspec_backend_cache(true)
       opts = @audit_report.get_opts(format, quiet, {})
       expect(opts['report']).to be true
       expect(opts['format']).to eq('json')
       expect(opts['output']).to eq('/dev/null')
       expect(opts['logger']).to eq(Chef::Log)
       expect(opts[:backend_cache]).to be true
+      expect(opts[:attributes].empty?).to be true
+    end
+    it 'sets the backend_cache to false' do
+      format = 'json'
+      quiet = true
+      set_inspec_backend_cache(false)
+      opts = @audit_report.get_opts(format, quiet, {})
+      expect(opts['report']).to be true
+      expect(opts['format']).to eq('json')
+      expect(opts['output']).to eq('/dev/null')
+      expect(opts['logger']).to eq(Chef::Log)
+      expect(opts[:backend_cache]).to be false
       expect(opts[:attributes].empty?).to be true
     end
     it 'sets the attributes' do
@@ -94,6 +135,7 @@ describe 'Chef::Handler::AuditReport methods' do
         first: 'value1',
         second: 'value2'
       }
+      set_inspec_backend_cache(true)
       opts = @audit_report.get_opts(format, quiet, attributes)
       expect(opts[:attributes][:first]).to eq('value1')
       expect(opts[:attributes][:second]).to eq('value2')


### PR DESCRIPTION
### Description

Add inspec caching attribute which defaults to true. This enables the new inspec caching when used by the Audit cookbook.

### Issues Resolved

Fixes https://github.com/chef-cookbooks/audit/issues/296

Signed-off-by: Jared Quick <jquick@chef.io>