### PR TITLE
Update reporters to log report size. Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,16 @@ Version compatibility matrix:
 |   ≥ 0.8.0          |   ≥ 1.24.0       |   ≥ 4.0.0                |
 
 
+#### Compliance Report size limitations
+
+The size of the report being generated from running the compliance scan is influenced by a few factors like:
+ * number of controls and tests in a profile
+ * number of profile failures for the node
+ * controls metadata (title, description, tags, etc)
+ * number of resources (users, processes, etc) that are being tested
+
+Depending on your setup, there are some limits you need to be aware of. A common one is Chef Server default (1MB) request size. Exceeding this limit will reject the report with `ERROR: 413 "Request Entity Too Large"`. For more details about these limits, please refer to [TROUBLESHOOTING.md](TROUBLESHOOTING.md#413-request-entity-too-large).
+
 #### Write to file on disk
 
 To write the report to a file on disk, simply set the `reporter` to 'json-file' like so:
@@ -570,7 +580,7 @@ node.normal['audit']['inspec_backend_cache'] = false
 
 ## Troubleshooting
 
-Please refer to TROUBLESHOOTING.md.
+Please refer to [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 Please let us know if you have any [issues](https://github.com/chef-cookbooks/audit/issues), we are happy to help.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 ## HTTP Errors
 
-**401, 403 Unauthorized - bad clock**
+### 401, 403 Unauthorized - bad clock
 
 Occasionally, the system date/time will drift between client and server.  If this drift is greater than a couple of minutes, the Chef Server will throw a 401 unauthorized and the request will not be forwarded to the Compliance server.
 
@@ -34,7 +34,7 @@ Additionally, the chef_gate log will contain a similar message:
 2016-08-28_15:01:34.88704 Error #01: Authentication failed. Please check your system's clock.
 ```
 
-**401 Token and Refresh Token Authentication**
+### 401 Token and Refresh Token Authentication
 
 In the event of a malformed or unset token, the Chef Compliance server will log the token error:
 ```
@@ -45,3 +45,45 @@ In the event of a malformed or unset token, the Chef Compliance server will log 
 ==> /var/log/chef-compliance/nginx/compliance.access.log <==
 192.168.200.102 - - [28/Aug/2016:21:23:46 +0000] "GET /api/owners/base/compliance/linux/tar HTTP/1.1" 401 0 "-" "Ruby"
 ```
+
+### 413 Request Entity Too Large
+
+If the `audit` cookbook report handler prints this stacktrace:
+```
+Running handlers:
+[2017-12-21T16:21:15+00:00] WARN: Compliance report size is 1.71 MB.
+[2017-12-21T16:21:15+00:00] ERROR: 413 "Request Entity Too Large" (Net::HTTPServerException)
+/opt/chef/embedded/lib/ruby/2.4.0/net/http/response.rb:122:in `error!'
+/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/http.rb:152:in `request'
+/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.6.4/lib/chef/http.rb:131:in `post'
+/var/chef/cache/cookbooks/audit/libraries/reporters/cs_automate.rb:37:in `block in send_report'
+...
+```
+
+and the Chef Server Nginx logs confirm the `413` error:
+```
+==> /var/log/opscode/nginx/access.log <==
+192.168.56.40 - - [21/Dec/2017:11:35:30 +0000]  "POST /organizations/eu_org/data-collector HTTP/1.1" 413 "0.803" 64 "-" "Chef Client/13.6.4 (ruby-2.4.2-p198; ohai-13.6.0; x86_64-linux; +https://chef.io)" "-" "-" "-" "13.6.4" "algorithm=sha1;version=1.1;" "bootstrapped-node" "2017-12-21T11:35:31Z" "GR6RyPvKkZDaGyQDYCPfoQGS8G4=" 1793064
+```
+
+you most likely hit the `erchef` request size in Chef Server that defaults to ~1MB. To double this limit, add the following line in Chef Server's `/etc/opscode/chef-server.rb`:
+```
+opscode_erchef['max_request_size'] = 2000000
+```
+and run `chef-server-ctl reconfigure` to apply this change.
+
+## Chef Automate Backend Errors
+
+If a Compliance report is not becoming available in the Chef Automate UI or API and this error shows up in the `logstash` logs:
+```
+/var/log/delivery/logstash/current
+2017-12-21_13:59:54.69949 DEBUG: Ruby filter is processing an 'inspec_profile' event
+2017-12-21_14:00:16.51553 java.lang.OutOfMemoryError: Java heap space
+2017-12-21_14:00:16.51556 Dumping heap to /opt/delivery/embedded/logstash/heapdump.hprof ...
+2017-12-21_14:00:16.51556 Unable to create /opt/delivery/embedded/logstash/heapdump.hprof: File exists
+2017-12-21_14:00:18.50676 Error: Your application used more memory than the safety cap of 383M.
+2017-12-21_14:00:18.50694 Specify -J-Xmx####m to increase it (#### = cap size in MB).
+2017-12-21_14:00:18.50703 Specify -w for full OutOfMemoryError stack trace
+```
+
+you have reached the java heap size(`-Xmx`) limit of `logstash`. This is automatically set during `automate-ctl reconfigure` to 10% of the system memory.

--- a/libraries/reporters/automate.rb
+++ b/libraries/reporters/automate.rb
@@ -38,6 +38,10 @@ module Reporter
       end
 
       json_report = enriched_report(report).to_json
+      report_size = json_report.bytesize
+      if report_size > 5*1024*1024
+        Chef::Log.warn "Compliance report size is #{(report_size / (1024*1024.0)).round(2)} MB."
+      end
 
       unless json_report
         Chef::Log.warn 'Something went wrong, report can\'t be nil'

--- a/libraries/reporters/compliance.rb
+++ b/libraries/reporters/compliance.rb
@@ -23,8 +23,12 @@ module Reporter
       req = Net::HTTP::Post.new(@url, { 'Authorization' => "Bearer #{@token}" })
 
       min_report = transform(report)
-      json_report = enriched_report(min_report, @source_location)
-      req.body = json_report.to_json
+      json_report = enriched_report(min_report, @source_location).to_json
+      req.body = json_report
+      report_size = json_report.bytesize
+      if report_size > 5*1024*1024
+        Chef::Log.warn "Compliance report size is #{(report_size / (1024*1024.0)).round(2)} MB."
+      end
 
       # TODO: use secure option
       uri = URI(@url)

--- a/libraries/reporters/cs_automate.rb
+++ b/libraries/reporters/cs_automate.rb
@@ -21,6 +21,10 @@ module Reporter
 
     def send_report(report)
       automate_report = enriched_report(report)
+      report_size = automate_report.to_json.bytesize
+      if report_size > 900*1024
+        Chef::Log.warn "Compliance report size is #{(report_size / (1024*1024.0)).round(2)} MB."
+      end
 
       if @insecure
         Chef::Config[:verify_api_cert] = false

--- a/libraries/reporters/cs_compliance.rb
+++ b/libraries/reporters/cs_compliance.rb
@@ -11,6 +11,10 @@ module Reporter
     def send_report(report)
       min_report = transform(report)
       cc_report = enriched_report(min_report, @source_location)
+      report_size = cc_report.to_json.bytesize
+      if report_size > 900*1024
+        Chef::Log.warn "Compliance report size is #{(report_size / (1024*1024.0)).round(2)} MB."
+      end
 
       # TODO: only disable if insecure option is set
       Chef::Config[:verify_api_cert] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '6.0.0'
+version '6.0.1'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'


### PR DESCRIPTION
Log the size of the report if it reaches sizes that might cause problems.
Document the limits.