### PR TITLE
Update the readme regarding audit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,20 @@ control "blog-1" do
 end
 ```
 
+### Disabling 'audit mode' in  the Chef client
+
+The audit cookbook and Chef's own "Audit Mode" are not compatible due to global state management done by RSpec which is used by both implementations. To prevent unexpected results, the audit cookbook will prevent Chef from continuing if "Audit Mode" is not disabled.
+
+You can use the [chef-client cookbook](https://supermarket.chef.io/cookbooks/chef-client) to disable "Audit Mode" on all of your nodes to permit use of the audit cookbook. As an example, when using the chef-client cookbook you can add this configuration to `default_attributes` section of a role and add the chef-client cookbook to the run list.
+
+```
+"chef_client": {
+  "config": {
+    "audit_mode": ":disabled"
+  }
+},
+```
+
 ## Interval Settings
 
 If you have long running audit profiles that you don't wish to execute on every chef-client run,


### PR DESCRIPTION
An error is now raised if you used the audit cookbook and audit mode is not disabled in the Chef client. This adds a note on how to disable audit mode.

https://github.com/chef-cookbooks/audit/commit/e41d0e99ad5da3e353e9fe167705bdd353b22aa3
