### PR TITLE
Add optional version parameter when using Compliance store

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ node.default['audit']['profiles'].push("path": "#{PROFILES_PATH}/mylinux-failure
       "name": "linux",
       "compliance": "base/linux"
     },
+    # profile from Chef Compliance at a particular version
+    {
+      "name": "linux-baseline",
+      "compliance": "user/linux-baseline",
+      "version": "2.1.0"
+    },
     # profile from supermarket
     # note: If reporting to Compliance, the Supermarket profile needs to be uploaded to Chef Compliance first
     {

--- a/files/default/vendor/chef-automate/fetcher.rb
+++ b/files/default/vendor/chef-automate/fetcher.rb
@@ -23,7 +23,11 @@ module ChefAutomate
         # verifies that the target e.g base/ssh exists
         profile = sanitize_profile_name(uri)
         owner, id = profile.split('/')
-        profile_path = "/compliance/profiles/#{owner}/#{id}/tar"
+        if target.respond_to?(:key?) && target.key?(:version)
+          profile_path = "/compliance/profiles/#{owner}/#{id}/version/#{target[:version]}/tar"
+        else
+          profile_path = "/compliance/profiles/#{owner}/#{id}/tar"
+        end
         dc = Chef::Config[:data_collector]
         url = URI(dc[:server_url])
         url.path = profile_path

--- a/files/default/vendor/chef-server/fetcher.rb
+++ b/files/default/vendor/chef-server/fetcher.rb
@@ -36,7 +36,12 @@ module ChefServer
       config = {
         'insecure' => true,
       }
-      new(target_url(profile, config), config)
+
+      if target.respond_to?(:key?) && target.key?(:version)
+        new(target_url(profile, config, target[:version]), config)
+      else
+        new(target_url(profile, config), config)
+      end
     rescue URI::Error => _e
       nil
     end
@@ -56,9 +61,13 @@ module ChefServer
       ''
     end
 
-    def self.target_url(profile, config)
+    def self.target_url(profile, config, version = nil)
       o, p = profile.split('/')
-      reqpath ="organizations/#{chef_server_org}/owners/#{o}/compliance/#{p}/tar"
+      if version
+        reqpath ="organizations/#{chef_server_org}/owners/#{o}/compliance/#{p}/version/#{version}/tar"
+      else
+        reqpath ="organizations/#{chef_server_org}/owners/#{o}/compliance/#{p}/tar"
+      end
 
       if config['insecure']
         Chef::Config[:verify_api_cert] = false


### PR DESCRIPTION
### Description

This change allows a user to specify what version of an InSpec profile to pull from the Compliance store in Automate when using the audit cookbook.

### Issues Resolved

There aren't any GitHub issues, but at least two customers have requested this functionality.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
