### PR TITLE
compat_resource is no longer supported

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,9 +10,7 @@ version '6.1.0'
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'
 
-chef_version '>= 12.5.1' if respond_to?(:chef_version)
-
-depends 'compat_resource'
+chef_version '>= 12.20' if respond_to?(:chef_version)
 
 supports 'aix'
 supports 'amazon'


### PR DESCRIPTION
this is breaking our internal use of the audit cookbook on chef-13
somehow by pulling this in as a dep.

this declares it drops support for chef <= 12.19 because that's the
last rev of chef-client that was pulled into compat_resource, i
don't know which features might specifically be getting used in
order to produce a lower threshold.  12.20.x is over a year old
though and that is still a wider window than our declared 6
month support window for cookbooks (and the EOL of the entire
Chef 12 line is imminently happening).

https://github.com/chef/chef-rfc/blob/master/rfc092-dependency-update-cadence.md#cookbook-and-ecosystem-tooling-support

