### PR TITLE
Bump audit major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v7.0.0](https://github.com/chef-cookbooks/audit/tree/v7.0.0) (2018-05-11)
+[Full Changelog](https://github.com/chef-cookbooks/audit/compare/v6.1.0...v7.0.0)
+
+**Merged pull requests:**
+
+- Update audit cookbook to use inspec-core. [\#318](https://github.com/chef-cookbooks/audit/pull/318) ([jquick](https://github.com/jquick))
+- compat\_resource is no longer supported [\#316](https://github.com/chef-cookbooks/audit/pull/316) ([lamont-granquist](https://github.com/lamont-granquist))
+
 ## [v6.1.0](https://github.com/chef-cookbooks/audit/tree/v6.1.0) (2018-04-19)
 [Full Changelog](https://github.com/chef-cookbooks/audit/compare/v6.0.2...v6.1.0)
 
@@ -9,6 +17,7 @@
 
 **Merged pull requests:**
 
+- Bump audit to 6.1.0. [\#315](https://github.com/chef-cookbooks/audit/pull/315) ([jquick](https://github.com/jquick))
 - Update Audit cookbook to support ChefClient 14 [\#313](https://github.com/chef-cookbooks/audit/pull/313) ([jquick](https://github.com/jquick))
 
 ## [v6.0.2](https://github.com/chef-cookbooks/audit/tree/v6.0.2) (2018-04-18)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '6.1.0'
+version '7.0.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

Due to the removal of `compat_resource` and the move to `inspec-core` we are doing a major bump of the cookbook.