### PR TITLE
[MSYS-829] Fix nil class error when profile not found on automate server

### DIFF
--- a/files/default/vendor/chef-server/fetcher.rb
+++ b/files/default/vendor/chef-server/fetcher.rb
@@ -99,6 +99,7 @@ module ChefServer
         rest.streaming_request(@target)
       end
       @archive_type = '.tar.gz'
+      raise "Unable to find requested profile on path: '#{@target.path}' on the Automate system." if archive.nil?
       Inspec::Log.debug("Archive stored at temporary location: #{archive.path}")
       @temp_archive_path = archive.path
     end


### PR DESCRIPTION
Fix `nil class` error when profile not found on automate server.
As per issue: https://github.com/chef-cookbooks/audit/issues/301

Signed-off-by: NAshwini <ashwini.nehate@msystechnologies.com>
