### PR TITLE
Allow json-file output location to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,9 @@ default['audit']['profiles'].push(
 )
 ```
 
-The resulting file will be written to `<chef_cache_path>/cookbooks/audit/inspec-<YYYYMMDDHHMMSS>.json`. The path will also be output to the Chef log:
+The resulting file will be written to `node['audit']['json_file']['location']` which defaults to
+`<chef_cache_path>/cookbooks/audit/inspec-<YYYYMMDDHHMMSS>.json`. The path will also be output to
+the Chef log:
 
 ```
 [2017-08-29T00:22:10+00:00] INFO: Reporting to json-file

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -93,3 +93,8 @@ default['audit']['attributes'] = {}
 # If enabled, a hash of the Chef "node" object will be sent to InSpec in an attribute
 # named `chef_node`
 default['audit']['chef_node_attribute_enabled'] = false
+
+# The location of the json-file output:
+# <chef_cache_path>/cookbooks/audit/inspec-<YYYYMMDDHHMMSS>.json
+default['audit']['json_file']['location'] =
+  File.expand_path(Time.now.utc.strftime('../../inspec-%Y%m%d%H%M%S.json'), __FILE__)

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -267,9 +267,7 @@ class Chef
             Chef::Log.warn "unable to determine chef-server url required by inspec report collector '#{reporter}'. Skipping..."
           end
         elsif reporter == 'json-file'
-          timestamp = Time.now.utc.strftime('%Y%m%d%H%M%S')
-          filename = 'inspec' << '-' << timestamp << '.json'
-          path = File.expand_path("../../../../#{filename}", __FILE__)
+          path = node['audit']['json_file']['location']
           Chef::Log.info "Writing report to #{path}"
           Reporter::JsonFile.new({ file: path }).send_report(report)
         else


### PR DESCRIPTION
Signed-off-by: Joe Nuspl <nuspl@nvwls.com>

### Description

Add `node['audit']['json_file']['location']` to specify the json-file output location

### Issues Resolved

https://github.com/chef-cookbooks/audit/issues/286

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
