### PR TITLE
Add support for node['audit']['profiles'] as a hash of hashes 

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -2,22 +2,42 @@
 driver:
   name: vagrant
 
+transport:
+  name: ssh
+
 provisioner:
-  name: chef_solo
+  name: chef_zero
 
 verifier:
   name: inspec
   sudo: true
 
 platforms:
-  - name: centos-7.1
-  - name: centos-6.7
-  - name: centos-5.11
+  - name: centos-6
+  - name: centos-7
   - name: ubuntu-14.04
-  - name: ubuntu-12.04
+  - name: ubuntu-16.04
 
 suites:
   - name: default
     run_list:
       - recipe[audit::default]
     attributes:
+      audit:
+        reporter: json-file
+        profiles:
+          - name: ssh-hardening
+            url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip
+          - name: ssh-baseline
+            supermarket: dev-sec/ssh-baseline
+  - name: hash
+    run_list:
+      - recipe[audit::default]
+    attributes:
+      audit:
+        reporter: json-file
+        profiles:
+          ssh-hardening:
+            url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip
+          ssh-baseline:
+            supermarket: dev-sec/ssh-baseline

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -78,7 +78,6 @@ suites:
         profiles:
           - name: ssh-hardening
             url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip
-          - git: https://github.com/dev-sec/tests-ssh-hardening.git
           - name: ssh-baseline
             supermarket: dev-sec/ssh-baseline
   - name: inspec-attributes
@@ -184,3 +183,14 @@ suites:
         reporter: json-file
         inspec_version: 1.25.1
         fail_if_not_present: true
+  - name: hash
+    run_list:
+      - recipe[audit::default]
+    attributes:
+      audit:
+        reporter: json-file
+        profiles:
+          ssh-hardening:
+            url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip
+          ssh-baseline:
+            supermarket: dev-sec/ssh-baseline

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,9 @@ matrix:
   - rvm: 2.3.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='chef-node-disabled-ubuntu-1404'
+  - rvm: 2.3.3
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='hash-centos-7'
+  - rvm: 2.3.3
+    script: bundle exec rake $SUITE
+    env: SUITE=test:integration OS='hash-ubuntu-1404'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # audit cookbook
 [![Cookbook Version](http://img.shields.io/cookbook/v/audit.svg)][cookbook] [![Build Status](http://img.shields.io/travis/chef-cookbooks/audit.svg)][travis]
 
-The `audit` cookbook allows you to run InSpec profiles as part of a Chef Client run. It downloads configured profiles from various sources like Chef Compliance, Chef Supermarket or Git and reports audit runs to Chef Compliance or Chef Automate.
+The `audit` cookbook allows you to run InSpec profiles as part of a Chef Client run. It downloads configured profiles from various sources like Chef Automate, Chef Supermarket or Git and reports audit runs to Chef Automate.
 
 ## Quickstart
 
@@ -116,6 +116,7 @@ default['audit']['reporter'] = 'chef-server-compliance'
 # Omit this to use the latest InSpec
 default['audit']['inspec-version'] = '1.29.0'
 
+# You may use an array of hashes (shown here) or hash of hashes (shown below)
 default['audit']['profiles'].push(
     # Profile from Chef Compliance
     {
@@ -152,6 +153,18 @@ default['audit']['profiles'].push(
       'url': 'https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip'
     }
 )
+```
+
+You may prefer to use hashes for your `node['audit']['profiles']` when you are merging attributes from multiple sources. Policyfiles do not merge arrays and in the case of Policyfiles with includes you will be able to append additional profiles with each Policyfile.
+
+```ruby
+# Hash of hashes, works with Policyfile includes
+default['audit']['profiles']['linux'] = { 'compliance': 'base/linux' }
+default['audit']['profiles']['linux-baseline'] = { 'compliance': 'user/linux-baseline', 'version': '2.1.0' }
+default['audit']['profiles']['ssh'] = { 'supermarket': 'hardening/ssh-hardening' }
+default['audit']['profiles']['brewinc/win2012_audit'] = { 'path': 'E:/profiles/win2012_audit' }
+default['audit']['profiles']['ssl'] = { 'git': 'https://github.com/dev-sec/ssl-benchmark.git' }
+default['audit']['profiles']['ssh2'] = { 'url': 'https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip' }
 ```
 
 #### Attributes

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -27,7 +27,17 @@ class Chef
         interval = node['audit']['interval']
         interval_enabled = node['audit']['interval']['enabled']
         interval_time = node['audit']['interval']['time']
-        profiles = node['audit']['profiles']
+        if node['audit']['profiles'].class.eql?(Chef::Node::ImmutableMash)
+          profiles = []
+          node['audit']['profiles'].keys.each do |p|
+            h = node['audit']['profiles'][p].to_hash
+            h['name'] = p
+            profiles.push(h)
+          end
+        else
+          Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
+          profiles = node['audit']['profiles']
+        end
         quiet = node['audit']['quiet']
         fetcher = node['audit']['fetcher']
         attributes = node['audit']['attributes'].to_h


### PR DESCRIPTION
Policyfiles with includes do not allow merging arrays and it's a bit unclear why an array was chosen. This patch does not change the existing behavior, only supplements it.

Signed-off-by: Matt Ray <matthewhray@gmail.com>