### PR TITLE
Switch to the new json-automate reporter when inspec version allows it

### DIFF
--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -6,6 +6,7 @@ class Chef
     # Creates a compliance audit report
     class AuditReport < ::Chef::Handler
       MIN_INSPEC_VERSION = '1.25.1'.freeze
+      MIN_INSPEC_VERSION_AUTOMATE_REPORTER = '2.2.64'.freeze
 
       def report
         # get reporter(s) from attributes as an array
@@ -68,9 +69,13 @@ class Chef
 
           # create a file with a timestamp to calculate interval timing
           create_timestamp_file if interval_enabled
+          reporter_format = 'json'
+          if Gem::Version.new(::Inspec::VERSION) >= Gem::Version.new(MIN_INSPEC_VERSION_AUTOMATE_REPORTER)
+            reporter_format = 'json-automate'
+          end
 
           # return hash of opts to be used by runner
-          opts = get_opts('json', quiet, attributes)
+          opts = get_opts(reporter_format, quiet, attributes)
 
           # instantiate inspec runner with given options and run profiles; return report
           report = call(opts, profiles)
@@ -138,7 +143,6 @@ class Chef
         require 'chef-automate/fetcher'
       end
 
-      # sets format to json-min when chef-compliance, json when chef-automate
       def get_opts(format, quiet, attributes)
         output = quiet ? ::File::NULL : $stdout
         Chef::Log.debug "Format is #{format}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '7.0.1'
+version '7.1.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'


### PR DESCRIPTION
### Description

The new `json-automate` reporter fixes a few bugs when inherited profiles are used. Released last week with inspec `v2.2.64`

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
