### PR TITLE
Remove Ruby 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ before_install:
 - bundle --version
 matrix:
   include:
-  - rvm: 2.2
-    script: bundle exec rake
   - rvm: 2.3.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-centos-7'

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,6 @@ source 'https://rubygems.org'
 
 gem 'chef', '>= 12.5.1'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
-  gem 'json', '~> 1.8'
-  gem 'rack', '< 2.0'
-  gem 'fauxhai', '< 3.10'
-end
-
 group :style do
   gem 'foodcritic', '~> 11.0'
   gem 'cookstyle', '~> 1.3'


### PR DESCRIPTION
I noticed a Travis failure on Ruby 2.2 on https://github.com/chef-cookbooks/audit/pull/340
But Ruby 2.2 was EOL six months ago: https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/

Chef 12 shipped with Ruby 2.1.2+ per https://github.com/chef/chef-rfc/blob/master/rfc015-chef-12.md#chef-12-1
Chef 12.14.11+ shipped with Ruby 2.3.1: https://github.com/chef/chef/commit/505a2baac3039b21ceb3fd815ccaeeba0321d1d8
Chef 14.0.1+ shipped with Ruby 2.4+: https://github.com/chef/chef/commit/aad8ccf126

We haven't shipped Ruby < 2.3 since 12.14 around August 2016.
