### PR TITLE
Update profiles default attribute to hash

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -85,7 +85,7 @@ default['audit']['overwrite'] = true
 
 # Chef Inspec Compliance profiles to be used for scan of node
 # See README.md for details
-default['audit']['profiles'] = []
+default['audit']['profiles'] = {}
 
 # Attributes used to run the given profiles
 default['audit']['attributes'] = {}


### PR DESCRIPTION
Signed-off-by: Jared Quick <jquick@chef.io>

### Description

When using a wrapper cookbook and trying to add to the profiles attribute using the new hash syntax it fails. This is because the base attribute is still set to an array instead of hash.

### Issues Resolved

This fixes  https://github.com/chef-cookbooks/audit/issues/339