### PR TITLE
Audit profiles array deprecation support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,8 +87,9 @@ default['audit']['overwrite'] = true
 # See README.md for details
 default['audit']['profiles'] = []
 
-# Extend the object and profile capability to support symbol assignment.
-# @TODO: Please remove these extend methods and change default['audit']['profiles'] = {} once we fully support hash of hashes profiles
+# 'default['audit']' and 'default['audit']['profiles']' capabilities are extended to support symbol assignment.
+# @TODO: Once we fully support hash of hashes, then we may remove these extended methods and revert back to using:
+# default['audit']['profiles'] = {}
 default['audit'].extend(Deprecations::Audit::HashProfile)
 default['audit']['profiles'].extend(Deprecations::Audit::ArrayProfile)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,6 +87,11 @@ default['audit']['overwrite'] = true
 # See README.md for details
 default['audit']['profiles'] = []
 
+# Extend the object and profile capability to support symbol assignment.
+# @TODO: Please remove these extend methods and change default['audit']['profiles'] = {} once we fully support hash of hashes profiles
+default['audit'].extend(Deprecations::Audit::HashProfile)
+default['audit']['profiles'].extend(Deprecations::Audit::ArrayProfile)
+
 # Attributes used to run the given profiles
 default['audit']['attributes'] = {}
 

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -29,10 +29,9 @@ class Chef
         interval_enabled = node['audit']['interval']['enabled']
         interval_time = node['audit']['interval']['time']
 
-        # profiles parsing for hash of hashes to array commented
-        # because it already store as array of profiles.
-        # @TODO: uncomment the code and remove direct assignment profiles = node['audit']['profiles']
-        # once when we fully support hash of hashes profiles
+        # Parsing hash of hashes ('profiles') into Array of hashes has been commented as of now.
+        # As we are already constructing the required array with an extension of (ArrayProfile & HashProfile)
+        # @TODO: uncomment it once when we will fully support hash of hashes (profiles')
         #
         profiles = node['audit']['profiles']
         # if node['audit']['profiles'].class.eql?(Chef::Node::ImmutableMash)

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -37,7 +37,7 @@ class Chef
           profiles = []
           node['audit']['profiles'].keys.each do |p|
             h = node['audit']['profiles'][p].to_hash
-            h['name'] = p
+            h[:name] = p unless h.key?('name') || h.key?(:name)
             profiles.push(h)
           end
         else

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -33,18 +33,16 @@ class Chef
         # As we are already constructing the required array with an extension of (ArrayProfile & HashProfile)
         # @TODO: uncomment it once when we will fully support hash of hashes (profiles')
         #
-        profiles = node['audit']['profiles']
-        # if node['audit']['profiles'].class.eql?(Chef::Node::ImmutableMash)
-        #   profiles = []
-        #   node['audit']['profiles'].keys.each do |p|
-        #     h = node['audit']['profiles'][p].to_hash
-        #     h['name'] = p
-        #     profiles.push(h)
-        #   end
-        # else
-        #   Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
-        #   profiles = node['audit']['profiles']
-        # end
+        if node['audit']['profiles'].class.eql?(Chef::Node::ImmutableMash)
+          profiles = []
+          node['audit']['profiles'].keys.each do |p|
+            h = node['audit']['profiles'][p].to_hash
+            h['name'] = p
+            profiles.push(h)
+          end
+        else
+          profiles = node['audit']['profiles']
+        end
         quiet = node['audit']['quiet']
         fetcher = node['audit']['fetcher']
         attributes = node['audit']['attributes'].to_h

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -28,17 +28,24 @@ class Chef
         interval = node['audit']['interval']
         interval_enabled = node['audit']['interval']['enabled']
         interval_time = node['audit']['interval']['time']
-        if node['audit']['profiles'].class.eql?(Chef::Node::ImmutableMash)
-          profiles = []
-          node['audit']['profiles'].keys.each do |p|
-            h = node['audit']['profiles'][p].to_hash
-            h['name'] = p
-            profiles.push(h)
-          end
-        else
-          Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
-          profiles = node['audit']['profiles']
-        end
+
+        # profiles parsing for hash of hashes to array commented
+        # because it already store as array of profiles.
+        # @TODO: uncomment the code and remove direct assignment profiles = node['audit']['profiles']
+        # once when we fully support hash of hashes profiles
+        #
+        profiles = node['audit']['profiles']
+        # if node['audit']['profiles'].class.eql?(Chef::Node::ImmutableMash)
+        #   profiles = []
+        #   node['audit']['profiles'].keys.each do |p|
+        #     h = node['audit']['profiles'][p].to_hash
+        #     h['name'] = p
+        #     profiles.push(h)
+        #   end
+        # else
+        #   Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
+        #   profiles = node['audit']['profiles']
+        # end
         quiet = node['audit']['quiet']
         fetcher = node['audit']['fetcher']
         attributes = node['audit']['attributes'].to_h

--- a/libraries/deprecations.rb
+++ b/libraries/deprecations.rb
@@ -1,0 +1,62 @@
+# encoding: utf-8
+# This module is use to support existing array as well as hash of hashes format
+# that are being assigned by end user.
+#
+# In order to provide backword compativility this module extended by profiles key object
+#
+module Deprecations
+  module Audit
+    # ArrayProfile module extend the hash instance object node['audit']['profiles']
+    # to add warning & format the array assignment.
+    module ArrayProfile
+      # @overload []=(*args)
+      # This method provide the support to assign item as hash(key as String|Symbole)
+      #
+      # @param [String|Symbole] key assigned add as name.
+      # @param [Hash] profile attributes the are being assigned.
+      #
+      # @example format the profile assignment if it is hash of hashes format.
+      #
+      #    node.default['audit']['profiles']['linux'] = { 'compalince': 'base/linux' }
+      #
+      # @example Formatted response return
+      #    { name: linux, 'compalince': 'base/linux' }
+      #
+      # @return [Array<Profiles>]
+      def []=(*args)
+        self << { name: args.first }.merge(args.last.to_h)
+      end
+
+      # @overload push(*args)
+      # WARN msg for the deprication use of array assigment.
+      # @param [Array] Profiles the are being assigned.
+      #
+      # @return [Array<Profiles>]
+      def push(*args)
+        Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
+        super(*args)
+      end
+    end
+
+    # HashProfile module extend the hash instance object node['audit'] to track
+    # re-assignment of the profiles.
+    module HashProfile
+      # @overload []=(key, val)
+      # WARN msg for the deprication use of array assigment.
+      # @param [String|Symbole] key of audit hash.
+      # @param [Array] profiles the are being re-assigned.
+      #
+      # @return [Hash, #key] return hash for non 'profiles' (key, value) pair assign
+      #
+      def []=(key, val)
+        if key.eql?('profiles')
+          Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
+          store(key, val)
+          self[key].extend(ArrayProfile)
+        else
+          super(key, val)
+        end
+      end
+    end
+  end
+end

--- a/libraries/deprecations.rb
+++ b/libraries/deprecations.rb
@@ -32,7 +32,7 @@ module Deprecations
         if key.is_a?(Integer)
           Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
         else
-          index = self.length
+          index = length
           value = { 'name': key }.merge(Hash.try_convert(value) || {})
         end
         super(index, value)
@@ -62,15 +62,18 @@ module Deprecations
         if key.eql?('profiles')
           unless val.is_a?(Hash)
             Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
+            store(key, val)
             self[key].extend(ArrayProfile)
+          else
+            store(key, val)
           end
-          store(key, val)
         else
           super(key, val)
         end
       end
 
       private
+
       # @param key<Object> The key to convert.
       #
       # @param [Object]
@@ -79,7 +82,7 @@ module Deprecations
       #
       # @api private
       def convert_key(key)
-        key.kind_of?(Symbol) ? key.to_s : key
+        key.is_a?(Symbol) ? key.to_s : key
       end
     end
   end

--- a/libraries/deprecations.rb
+++ b/libraries/deprecations.rb
@@ -24,7 +24,7 @@ module Deprecations
       #
       # @return [Array<Profiles>]
       def []=(*args)
-        self << { name: args.first }.merge(args.last.to_h)
+        self << { name: args.first }.merge(Hash.try_convert(args.last) || {})
       end
 
       # @overload push(*args)

--- a/libraries/deprecations.rb
+++ b/libraries/deprecations.rb
@@ -2,7 +2,7 @@
 # This module is use to support existing array as well as hash of hashes format
 # that are being assigned by end user.
 #
-# In order to provide backword compativility this module extended by profiles key object
+# In order to provide backward compatibility this module extended by profiles key object
 #
 module Deprecations
   module Audit
@@ -10,9 +10,9 @@ module Deprecations
     # to add warning & format the array assignment.
     module ArrayProfile
       # @overload []=(*args)
-      # This method provide the support to assign item as hash(key as String|Symbole)
+      # This method provide the support to assign item as hash(key as String|Symbol)
       #
-      # @param [String|Symbole] key assigned add as name.
+      # @param [String|Symbol] key assigned add as name.
       # @param [Hash] profile attributes the are being assigned.
       #
       # @example format the profile assignment if it is hash of hashes format.
@@ -43,7 +43,7 @@ module Deprecations
     module HashProfile
       # @overload []=(key, val)
       # WARN msg for the use of array assigment.
-      # @param [String|Symbole] key of audit hash.
+      # @param [String|Symbol] key of audit hash.
       # @param [Array] profiles the are being re-assigned.
       #
       # @return [Hash, #key] return hash for non 'profiles' (key, value) pair assign

--- a/libraries/deprecations.rb
+++ b/libraries/deprecations.rb
@@ -9,8 +9,8 @@ module Deprecations
     # ArrayProfile module extend the hash instance object node['audit']['profiles']
     # to add warning & format the array assignment.
     module ArrayProfile
-      EXCLUDE_METHODS = [:[]=]
       MUTATOR_METHODS = Chef::Node::Mixin::ImmutablizeArray::DISALLOWED_MUTATOR_METHODS
+
       # @overload []=(*args)
       # This method provide the support to assign item as hash(key as String|Symbol)
       #
@@ -33,13 +33,13 @@ module Deprecations
           Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
         else
           index = self.length
-          value = { name: key }.merge(Hash.try_convert(value) || {})
+          value = { 'name': key }.merge(Hash.try_convert(value) || {})
         end
         super(index, value)
       end
 
       # For all methods that may mutate an Array override them and raise warning
-      (MUTATOR_METHODS - EXCLUDE_METHODS).each do |mutator|
+      (MUTATOR_METHODS - [:[]=]).each do |mutator|
         define_method(mutator) do |*args, &block|
           Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
           super(*args, &block)
@@ -58,13 +58,28 @@ module Deprecations
       # @return [Hash, #key] return hash for non 'profiles' (key, value) pair assign
       #
       def []=(key, val)
+        key = convert_key(key)
         if key.eql?('profiles')
-          Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes." unless val.is_a?(Hash)
+          unless val.is_a?(Hash)
+            Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
+            self[key].extend(ArrayProfile)
+          end
           store(key, val)
-          self[key].extend(ArrayProfile)
         else
           super(key, val)
         end
+      end
+
+      private
+      # @param key<Object> The key to convert.
+      #
+      # @param [Object]
+      #   The converted key. If the key was a symbol, it will be converted to a
+      #   string.
+      #
+      # @api private
+      def convert_key(key)
+        key.kind_of?(Symbol) ? key.to_s : key
       end
     end
   end

--- a/libraries/deprecations.rb
+++ b/libraries/deprecations.rb
@@ -28,7 +28,7 @@ module Deprecations
       end
 
       # @overload push(*args)
-      # WARN msg for the deprication use of array assigment.
+      # WARN msg for the use of array assigment.
       # @param [Array] Profiles the are being assigned.
       #
       # @return [Array<Profiles>]
@@ -42,7 +42,7 @@ module Deprecations
     # re-assignment of the profiles.
     module HashProfile
       # @overload []=(key, val)
-      # WARN msg for the deprication use of array assigment.
+      # WARN msg for the use of array assigment.
       # @param [String|Symbole] key of audit hash.
       # @param [Array] profiles the are being re-assigned.
       #

--- a/spec/unit/libraries/deprecations_spec.rb
+++ b/spec/unit/libraries/deprecations_spec.rb
@@ -1,0 +1,82 @@
+# encoding: utf-8
+#
+# Cookbook Name:: audit
+# Spec:: deprecations
+
+require 'spec_helper'
+require_relative '../../../libraries/deprecations'
+
+describe 'Deprecations::Audit::ArrayProfile methods' do
+  let(:audit) { Hash.new }
+
+  before :each do
+    audit['profiles'] = []
+    audit['profiles'].extend(Deprecations::Audit::ArrayProfile)
+  end
+
+  describe '#[]=' do
+    it 'works well when used like a hash' do
+      expect { audit['profiles']['linux'] = { 'compliance': 'base/linux' } }.not_to raise_error
+    end
+    it 'does not affect any other object' do
+      audit['others'] = []
+      expect { audit['others']['linux'] = { 'compliance': 'base/linux' } }.to raise_error(TypeError)
+    end
+    it 'return a formatted array of hashes' do
+      audit['profiles']['linux'] = { 'compliance': 'base/linux' }
+      expect(audit['profiles']).to eq([{ 'name': 'linux', 'compliance': 'base/linux' }])
+    end
+  end
+
+  describe '#push' do
+    it 'warn with a deprecated message and return the formatted array of hashes' do
+      expect(Chef::Log).to receive(:warn).with("Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes.")
+      audit['profiles'].push({ 'name': 'linux', 'compliance': 'base/linux' })
+      expect(audit['profiles']).to eq([{ 'name': 'linux', 'compliance': 'base/linux' }])
+    end
+  end
+end
+
+describe 'Deprecations::Audit::HashProfile methods' do
+  let(:audit) { Hash.new }
+
+  describe '#[]=' do
+    context 'extended with audit hash' do
+      before :each do
+        audit['profiles'] = []
+        audit.extend(Deprecations::Audit::HashProfile)
+      end
+
+      it 'does not affect any other key' do
+        expect(Chef::Log).not_to receive(:warn)
+        audit['quiet'] = false
+        expect(audit['quiet']).to eq(false)
+      end
+
+      it 'warn if re-assign as array and return array of hashes' do
+        expect(Chef::Log).to receive(:warn)
+        audit['profiles'] = [{ 'name': 'linux', 'compliance': 'base/linux' }]
+        expect(audit['profiles']).to eq([{ 'name': 'linux', 'compliance': 'base/linux' }])
+      end
+    end
+
+    context 'not extended audit hash' do
+      before :each do
+        audit['profiles'] = []
+      end
+
+      it 'does not warn if re-assign' do
+        expect(Chef::Log).not_to receive(:warn)
+        audit['profiles'] = [{ 'name': 'linux', 'compliance': 'base/linux' }]
+        expect(audit['profiles']).to eq([{ 'name': 'linux', 'compliance': 'base/linux' }])
+      end
+
+      it 'does not warn for push method' do
+        expect(Chef::Log).not_to receive(:warn)
+        audit['profiles'] = [{ 'name': 'apache', 'compliance': 'base/apache' }]
+        audit['profiles'].push({ 'name': 'linux', 'compliance': 'base/linux' })
+        expect(audit['profiles'].length).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

Patch to support both array of hashes & hash of hashes profiles format.
- Added deprecations warning if profiles added by re-assign with array of hashes or push methods.
- Extended default profiles object, so that it will support new format(hash of hashes).
- Constructed final array of hashes while adding profiles so that no need to parse the profiles in audit report.

### Issues Resolved

Fixes: https://github.com/chef-cookbooks/audit/issues/339

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
