### PR TITLE
Fixes for undefined method 'path' for <String> when profile not found…

### DIFF
--- a/files/default/vendor/chef-server/fetcher.rb
+++ b/files/default/vendor/chef-server/fetcher.rb
@@ -99,7 +99,7 @@ module ChefServer
         rest.streaming_request(@target)
       end
       @archive_type = '.tar.gz'
-      raise_not_found if archive.nil?
+      raise "Unable to find requested profile on path: '#{target_path}' on the Automate system." if archive.nil?
       Inspec::Log.debug("Archive stored at temporary location: #{archive.path}")
       @temp_archive_path = archive.path
     end
@@ -131,10 +131,6 @@ module ChefServer
     def chef_server_url
       m = %r{^#{@config['server']}/owners/(?<owner>[^/]+)/compliance/(?<id>[^/]+)/tar$}.match(@target)
       "#{m[:owner]}/#{m[:id]}"
-    end
-
-    def raise_not_found
-      raise "Unable to find requested profile on path: '#{target_path}' on the Automate system."
     end
 
     def target_path

--- a/files/default/vendor/chef-server/fetcher.rb
+++ b/files/default/vendor/chef-server/fetcher.rb
@@ -99,7 +99,7 @@ module ChefServer
         rest.streaming_request(@target)
       end
       @archive_type = '.tar.gz'
-      raise "Unable to find requested profile on path: '#{@target.path}' on the Automate system." if archive.nil?
+      raise_not_found if archive.nil?
       Inspec::Log.debug("Archive stored at temporary location: #{archive.path}")
       @temp_archive_path = archive.path
     end
@@ -131,6 +131,15 @@ module ChefServer
     def chef_server_url
       m = %r{^#{@config['server']}/owners/(?<owner>[^/]+)/compliance/(?<id>[^/]+)/tar$}.match(@target)
       "#{m[:owner]}/#{m[:id]}"
+    end
+
+    def raise_not_found
+      raise "Unable to find requested profile on path: '#{target_path}' on the Automate system."
+    end
+
+    def target_path
+      return @target.path if @target.respond_to?(:path)
+      @target
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>

### Description

Report handler Chef::Handler::AuditReport raised NoMethodError: undefined method 'path' for <String> when profile not found

 - Added check on a `@target` object for responding `.path` or not.
 - If `@target` respond to `.path`  then return `@target.path` otherwise return `@target` object itself.
 

### Issues Resolved

https://github.com/chef-cookbooks/audit/issues/348

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
