### PR TITLE
Fixing broken link to data collection docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ default['audit']['profiles'].push(
 )
 ```
 
-If you are using a self-signed certificate, please also read [how to add the Chef Automate certificate to the trusted_certs directory](https://docs.chef.io/setup_visibility_chef_automate.html#add-chef-automate-certificate-to-trusted-certs-directory)
+If you are using a self-signed certificate, please also read [how to add the Chef Automate certificate to the trusted_certs directory](https://docs.chef.io/data_collection_without_server.html#add-chef-automate-certificate-to-trusted-certs-directory)
 
 Version compatibility matrix:
 


### PR DESCRIPTION
Signed-off-by: Shaun Mouton <smouton@chef.io>

### Description

fixes a broken link documenting how to add a self-signed Automate certificate to the /etc/chef/trusted_certs directory on clients

### Issues Resolved

n/a

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
