### PR TITLE
[WIP] Initial POC of using custom_resources [WIP]

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -194,3 +194,13 @@ suites:
             url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip
           ssh-baseline:
             supermarket: dev-sec/ssh-baseline
+  - name: custom_resource
+    run_list:
+      - recipe[audit::default]
+      - recipe[test_helper::custom_resources]
+    attributes:
+      audit:
+        reporter: json-file
+        profiles:
+          ssh-hardening:
+            url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -28,17 +28,8 @@ class Chef
         interval = node['audit']['interval']
         interval_enabled = node['audit']['interval']['enabled']
         interval_time = node['audit']['interval']['time']
-        if node['audit']['profiles'].class.eql?(Chef::Node::ImmutableMash)
-          profiles = []
-          node['audit']['profiles'].keys.each do |p|
-            h = node['audit']['profiles'][p].to_hash
-            h['name'] = p
-            profiles.push(h)
-          end
-        else
-          Chef::Log.warn "Use of a hash array for the node['audit']['profiles'] is deprecated. Please refer to the README and use a hash of hashes."
-          profiles = node['audit']['profiles']
-        end
+
+        profiles = node.run_state['audit']['profiles'] || []
         quiet = node['audit']['quiet']
         fetcher = node['audit']['fetcher']
         attributes = node['audit']['attributes'].to_h

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,4 +29,7 @@ end
 
 include_recipe 'audit::inspec'
 
+audit_config 'default' do
+end
+
 load_audit_handler

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,0 +1,44 @@
+provides :audit_config
+resource_name :audit_config
+
+property :profiles, [Array, Hash], default: lazy { node['audit']['profiles'] }
+
+action :run do
+  setup_run_state
+end
+
+# This is used by the other resource to ensure that our runstate is configured
+# without having to handle all the other audit config setup we will eventually
+# need
+action :init do
+  setup_run_state
+end
+
+action_class do
+  # We need to check to see if the profiles is an Hash of Hashes and needs to
+  # be upgraded to an Array of Hashes
+  # The reason this might be a hash is to support `include_policy` in
+  # PolicyFiles setting profiles to run
+  def get_profile_list
+    return new_resource.profiles.dup if new_resource.profiles.is_a?(Array)
+    update_to_array(new_resource.profiles.dup)
+  end
+
+  def update_to_array(profiles)
+    log "Current profile list is a Hash, converting to an array: #{profiles.inspect}"
+
+    profiles.keys.inject([]) do |c,name|
+      profile = profiles[name]
+      profile['name'] = name
+      c << profile
+      c
+    end
+  end
+
+  # store current profile list in the run_state
+  def setup_run_state
+    node.run_state['audit'] ||= {}
+    node.run_state['audit']['profiles'] ||= []
+    node.run_state['audit']['profiles'] += get_profile_list
+  end
+end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -37,8 +37,6 @@ action_class do
 
   # store current profile list in the run_state
   def setup_run_state
-    node.run_state['audit'] ||= {}
-    node.run_state['audit']['profiles'] ||= []
-    node.run_state['audit']['profiles'] += get_profile_list
+    node.run_state['audit'] ||= { 'profiles' => get_profile_list }
   end
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -16,9 +16,10 @@ end
 
 action_class do
   # We need to check to see if the profiles is an Hash of Hashes and needs to
-  # be upgraded to an Array of Hashes
-  # The reason this might be a hash is to support `include_policy` in
-  # PolicyFiles setting profiles to run
+  # be upgraded to an Array of Hashes.
+  # The reason we go to the Array format instead of the newer Hash format is
+  # the audit report handler converts the hash back to an array and this
+  # greatly simplifies the code over there needed to handle this.
   def get_profile_list
     return new_resource.profiles.dup if new_resource.profiles.is_a?(Array)
     update_to_array(new_resource.profiles.dup)

--- a/resources/profile.rb
+++ b/resources/profile.rb
@@ -1,0 +1,48 @@
+provides :audit_profile
+resource_name :audit_profile
+
+property :profile_name, String, name_property: true
+property :compliance, String
+property :git, String
+property :path, String
+property :url, String
+property :supermarket, String
+property :version, String
+
+action :add do
+  # if no source is defined assumed that that the name is what we are using and
+  # that we are pulling from compliance
+  node.run_state['audit'] ||= { 'profiles': {} }
+
+  profile_name = new_resource.profile_name
+
+  source_properties.each do |prop|
+    next unless property_is_set?(prop.to_sym)
+    add_profile({ "name" => profile_name, prop.to_s => new_resource.send(prop.to_sym) })
+    break # for now we just quit out because we don't want to add the profile multiple times
+  end
+  # TODO: check to make sure we set something and throw an error if not
+  # TODO: Determine if we should throw an error if more than one source is defined
+end
+
+action_class do
+  def add_profile(profile)
+    # make sure we have the initial run_state set for audit to work
+    audit_config 'default' do
+      action :init
+    end
+
+    profile_index = node.run_state['audit']['profiles'].index { |p| p['name'] == profile['name'] }
+
+    if profile_index.nil?
+      node.run_state['audit']['profiles'] << profile
+    else
+      log "Skipped adding profile #{profile["name"]}, already added"
+    end
+  end
+
+  # properties that might contain source info for the profile
+  def source_properties
+    %w{ compliance git path url supermarket }
+  end
+end

--- a/test/cookbooks/test_helper/recipes/custom_resources.rb
+++ b/test/cookbooks/test_helper/recipes/custom_resources.rb
@@ -1,0 +1,7 @@
+audit_profile 'ssh-baseline' do
+  supermarket 'dev-sec/ssh-baseline'
+end
+
+audit_profile 'ssh-baseline' do
+  supermarket 'dev-sec/ssh-baseline'
+end

--- a/test/cookbooks/test_helper/recipes/custom_resources.rb
+++ b/test/cookbooks/test_helper/recipes/custom_resources.rb
@@ -2,6 +2,7 @@ audit_profile 'ssh-baseline' do
   supermarket 'dev-sec/ssh-baseline'
 end
 
+# this one will be skipped because it was already added by the previous one
 audit_profile 'ssh-baseline' do
-  supermarket 'dev-sec/ssh-baseline'
+  compliance 'admin/ssh-baseline'
 end


### PR DESCRIPTION
# WORK IN PROGRESS DO NOT MERGE 

### Description

The idea here is to replace the attribute driven nature of this cookbook with custom resources.  

One primary driver for this is to make it easier to handle the transition between the profile list being an Array of Hashes vs. a Hash of Hashes (https://github.com/chef-cookbooks/audit#configure-node) and the errors and confusion that happens when users try to use hash syntax to add a profile to the default array format.  

One difficulty is the report handler pulls the list of profiles from the node attributes.  Which it appears cannot be modified inside a custom resource. To get around this, I've changed it to use `node.run_state`, which is transient and doesn't get saved to the chef-server.  If someone needs those to show up there, then they can still use the old method to do that.  

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
