### PR TITLE
Prevent failures when running on Chef 15

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,7 @@
 # Cookbook Name:: audit
 # Recipe:: default
 #
-# Copyright 2016 Chef Software, Inc.
+# Copyright 2016-2019 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 # due to global state management done by RSpec which is used by both
 # implementations. To prevent unexpected results, the audit cookbook
 # will prevent Chef from continuing if Audit Mode is not disabled.
-unless Chef::Config[:audit_mode] == :disabled
+unless Chef::Config[:audit_mode] == :disabled || Gem::Requirement.new('>= 15').satisfied_by?(Gem::Version.new(Chef::VERSION))
   raise 'Audit Mode is enabled. The audit cookbook and Audit Mode' \
     ' cannot be used at the same time. Please disable Audit Mode' \
     ' in your client configuration.'


### PR DESCRIPTION
Audit mode isn't a thing in Chef 15 so the config we're checking here
doesn't exist.

Signed-off-by: Tim Smith <tsmith@chef.io>