### PR TITLE
Update to kitchen-dokken ~> 2.7.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -83,6 +83,8 @@ suites:
     attributes:
       audit:
         reporter: json-file
+        json_file:
+          location: <%= File.join('/tmp', Time.now.utc.strftime('inspec-%Y%m%d%H%M%S.json')) %>
         profiles:
           - git: https://github.com/mhedgpeth/attribute-file-exists-profile.git
         attributes:
@@ -93,6 +95,8 @@ suites:
     attributes:
       audit:
         reporter: json-file
+        json_file:
+          location: <%= File.join('/tmp', Time.now.utc.strftime('inspec-%Y%m%d%H%M%S.json')) %>
         profiles:
           - url: https://github.com/adamleff/inspec-profile-chef-node-attributes/archive/master.tar.gz
         chef_node_attribute_enabled: true
@@ -102,6 +106,8 @@ suites:
     attributes:
       audit:
         reporter: json-file
+        json_file:
+          location: <%= File.join('/tmp', Time.now.utc.strftime('inspec-%Y%m%d%H%M%S.json')) %>
         profiles:
           - url: https://github.com/adamleff/inspec-profile-chef-node-attributes/archive/master.tar.gz
   - name: missing-profile-no-fail
@@ -149,8 +155,6 @@ suites:
       - recipe[audit::default]
     driver:
       chef_version: 15
-    provisioner:
-      chef_options: ' -z --chef-license accept-no-persist'
     attributes:
       audit:
         reporter: json-file

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
     env: SUITE=test:integration OS='missing-profile-fail-ubuntu-1804'
   - rvm: 2.6.3
     script: rake $SUITE
-    env: SUITE=test:integration OS='chef15-compatible-inspec-ubuntu-1804'
+    env: SUITE=test:integration OS='chef15-compatible-inspec-ubuntu-1804' CHEF_LICENSE="accept-no-persist"
   - rvm: 2.6.3
     script: rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version4-centos-7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,47 +31,47 @@ before_install:
 matrix:
   include:
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='default-centos-7'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='default-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='missing-profile-no-fail-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE && exit 1 || echo "OK"
+    script: rake $SUITE && exit 1 || echo "OK"
     env: SUITE=test:integration OS='missing-profile-fail-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='chef15-compatible-inspec-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version4-centos-7'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version3-centos-7'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version4-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version3-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version2-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='inspec-attributes-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='chef-node-enabled-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='chef-node-disabled-ubuntu-1804'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='hash-centos-7'
   - rvm: 2.6.3
-    script: bundle exec rake $SUITE
+    script: rake $SUITE
     env: SUITE=test:integration OS='hash-ubuntu-1804'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,62 +1,77 @@
 branches:
   only:
   - master
+
 language: ruby
-cache: bundler
+
+addons:
+  apt:
+    sources:
+      - chef-current-trusty
+    packages:
+      - chefdk
+
+# Don't `bundle install` which takes about 1.5 mins
+install: echo "skip bundle install"
 
 # necessary for docker to work
 sudo: required
 dist: trusty
+
 services:
 - docker
+
 before_install:
-- gem update --system
-- gem --version
-- bundle --version
+- sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+- eval "$(chef shell-init bash)"
+- chef --version
+- cookstyle --version
+- foodcritic --version
+
 matrix:
   include:
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-centos-7'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='default-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='missing-profile-no-fail-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE && exit 1 || echo "OK"
     env: SUITE=test:integration OS='missing-profile-fail-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='chef15-compatible-inspec-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version4-centos-7'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version3-centos-7'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version4-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version3-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='gem-install-core-version2-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='inspec-attributes-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='chef-node-enabled-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='chef-node-disabled-ubuntu-1804'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='hash-centos-7'
-  - rvm: 2.3.3
+  - rvm: 2.6.3
     script: bundle exec rake $SUITE
     env: SUITE=test:integration OS='hash-ubuntu-1804'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ addons:
     packages:
       - chefdk
 
-# Don't `bundle install` which takes about 1.5 mins
-install: echo "skip bundle install"
-
 # necessary for docker to work
 sudo: required
 dist: trusty

--- a/Gemfile
+++ b/Gemfile
@@ -1,29 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'chef', '>= 12.5.1'
-
-group :style do
-  gem 'foodcritic', '~> 11.0'
-  gem 'cookstyle', '~> 1.3'
-end
-
-group :test do
-  gem 'rake', '>= 11.3'
-  gem 'berkshelf', '>= 5.6'
-  gem 'chefspec',  '~> 7.0'
-  gem 'coveralls', '~> 0.8.2', require: false
-  gem 'rb-readline'
-  gem 'webmock'
-  gem 'fauxhai', '~> 5.2'
-end
-
-group :integration do
-  gem 'test-kitchen', '~> 1.16'
-  gem 'kitchen-dokken', '~> 2.7.0'
-  gem 'kitchen-ec2', '~> 1.2'
-  gem 'kitchen-inspec', '~> 0.18'
-end
-
 group :release do
   gem 'community_cookbook_releaser'
   gem 'stove'

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 
 group :integration do
   gem 'test-kitchen', '~> 1.16'
-  gem 'kitchen-dokken', '= 2.6.0'
+  gem 'kitchen-dokken', '~> 2.7.0'
   gem 'kitchen-ec2', '~> 1.2'
   gem 'kitchen-inspec', '~> 0.18'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -48,13 +48,13 @@ namespace :test do
   task :integration do
     concurrency = ENV['CONCURRENCY'] || 1
     os = ENV['OS'] || ''
-    sh('sh', '-c', "bundle exec kitchen test -c #{concurrency} #{os}")
+    sh('sh', '-c', "kitchen test -c #{concurrency} #{os}")
   end
 
   # call it like this: rake test:kitchen_automate[verify]
   task :kitchen_automate, :action do |_t, args|
     if %w(list create converge verify destroy test).include?(args[:action])
-      sh('sh', '-c', "cd test/kitchen-automate; bundle exec kitchen #{args[:action]}")
+      sh('sh', '-c', "cd test/kitchen-automate; kitchen #{args[:action]}")
     else
       puts ">>> Unknown kitchen action: #{args[:action]}"
     end

--- a/test/integration/chef-node-disabled/default.rb
+++ b/test/integration/chef-node-disabled/default.rb
@@ -1,5 +1,5 @@
 # get most recent json-file output
-json_file = command('ls -t /opt/kitchen/cache/cookbooks/audit/inspec-*.json').stdout.lines.first.chomp
+json_file = command('ls -t /tmp/inspec-*.json').stdout.lines.first.chomp
 controls = json(json_file).profiles.first['controls']
 results = []
 controls.each do |c|

--- a/test/integration/chef-node-enabled/default.rb
+++ b/test/integration/chef-node-enabled/default.rb
@@ -1,5 +1,5 @@
 # get most recent json-file output
-json_file = command('ls -t /opt/kitchen/cache/cookbooks/audit/inspec-*.json').stdout.lines.first.chomp
+json_file = command('ls -t /tmp/inspec-*.json').stdout.lines.first.chomp
 controls = json(json_file).profiles.first['controls']
 results = []
 controls.each do |c|

--- a/test/integration/inspec-attributes/default.rb
+++ b/test/integration/inspec-attributes/default.rb
@@ -1,5 +1,5 @@
 # get most recent json-file output
-json_file = command('ls -t /opt/kitchen/cache/cookbooks/audit/inspec-*.json').stdout.lines.first.chomp
+json_file = command('ls -t /tmp/inspec-*.json').stdout.lines.first.chomp
 
 # ensure the control we expect is present and passed
 controls = json(json_file).profiles.first['controls']


### PR DESCRIPTION
### Description

Update to the latest `kitchen-dokken` driver so we can ensure that we are always pulling the latest chef image, see: someara/kitchen-dokken#181.  This makes running tests locally much more consistent.

Switch to using ChefDK in Travis so we can properly handle Chef-15 license acceptance.

This aligns the Travis testing to be handled similarly to what is in `chef-cookbooks/chef-client`

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
