### PR TITLE
Provide option to avoid saving the inspec attributes to the node object

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ Naming/AccessorMethodName:
   Exclude:
     - 'examples/chef-server/Vagrantfile'
     - 'spec/unit/report/audit_report_spec.rb'
+
+Style/BracesAroundHashParameters:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -597,13 +597,20 @@ Please let us know if you have any [issues](https://github.com/chef-cookbooks/au
 
 ## Run the tests for this cookbook:
 
+Install [Chef Development Kit](https://downloads.chef.io/chefdk) on your machine.
+
 ```bash
-bundle install
-bundle exec rake style
-# run all ChefSpec tests
-bundle exec rspec
-# run a specific test
-bundle exec rspec ./spec/unit/libraries/automate_spec.rb
+# Install webmock gem needed by rspec
+chef gem install webmock
+
+# Run style checks
+rake style
+
+# Run all unit and ChefSpec tests
+rspec
+
+# Run a specific test
+rspec ./spec/unit/libraries/automate_spec.rb
 ```
 
 ## How to release the `audit` cookbook

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,6 +90,9 @@ default['audit']['profiles'] = []
 # Attributes used to run the given profiles
 default['audit']['attributes'] = {}
 
+# Set this to false if you don't want ['audit']['attributes'] to be saved in the node object and stored in Chef Server or Automate. Useful if you are passing sensitive data to the inspec profile via the attributes.
+default['audit']['attributes_save'] = true
+
 # If enabled, a hash of the Chef "node" object will be sent to InSpec in an attribute
 # named `chef_node`
 default['audit']['chef_node_attribute_enabled'] = false

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -41,7 +41,8 @@ class Chef
         end
         quiet = node['audit']['quiet']
         fetcher = node['audit']['fetcher']
-        attributes = node['audit']['attributes'].to_h
+
+        attributes = node.run_state['audit_attributes'].to_h
 
         # add chef node data as an attribute if enabled
         attributes['chef_node'] = chef_node_attribute_data if node['audit']['chef_node_attribute_enabled']

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -116,6 +116,13 @@ module ReportHelpers
     File.expand_path('../../files/default/handler', __FILE__)
   end
 
+  # Copies ['audit']['attributes'] into run_state for the audit_handler to read them later
+  # Deletes ['audit']['attributes'] if instructed by ['audit']['attributes_save']
+  def copy_audit_attributes
+    node.run_state['audit_attributes'] = node['audit']['attributes']
+    node.rm('audit','attributes') unless node['audit']['attributes_save']
+  end
+
   def load_audit_handler
     libpath = ::File.join(cookbook_handler_path, 'audit_report')
     Chef::Log.info("loading handler from #{libpath}")

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -120,7 +120,7 @@ module ReportHelpers
   # Deletes ['audit']['attributes'] if instructed by ['audit']['attributes_save']
   def copy_audit_attributes
     node.run_state['audit_attributes'] = node['audit']['attributes']
-    node.rm('audit','attributes') unless node['audit']['attributes_save']
+    node.rm('audit', 'attributes') unless node['audit']['attributes_save']
   end
 
   def load_audit_handler

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '7.7.0'
+version '7.8.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,4 +29,6 @@ end
 
 include_recipe 'audit::inspec'
 
+# Call helper methods located in libraries/helper.rb
+copy_audit_attributes
 load_audit_handler

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -175,4 +175,39 @@ describe 'audit::default' do
       expect { chef_run }.to_not raise_error
     end
   end
+
+  context 'when audit attributes are not removed' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.9')
+      runner.node.override['audit']['attributes']['my-inspec-attribute'] = 'ok'
+      runner.converge(described_recipe)
+    end
+    it 'still contains the audit attributes after converge' do
+      expect(chef_run.node.attributes['audit']['attributes']).to eq({"my-inspec-attribute"=>"ok"})
+    end
+    it "should contain the inspec attributes in the run_state" do
+      expect(chef_run.node.run_state['audit_attributes']).to eq({"my-inspec-attribute"=>"ok"})
+    end
+    it 'should not raise an exception' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+
+  context 'when audit attributes are removed' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.9')
+      runner.node.override['audit']['attributes']['my-inspec-attribute'] = 'ok'
+      runner.node.override['audit']['attributes_save'] = false
+      runner.converge(described_recipe)
+    end
+    it 'should not contain the audit attributes after converge' do
+      expect(chef_run.node.attributes['audit']['attributes']).to eq(nil)
+    end
+    it "should contain the inspec attributes in the run_state" do
+      expect(chef_run.node.run_state['audit_attributes']).to eq({"my-inspec-attribute"=>"ok"})
+    end
+    it 'should not raise an exception' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -183,10 +183,10 @@ describe 'audit::default' do
       runner.converge(described_recipe)
     end
     it 'still contains the audit attributes after converge' do
-      expect(chef_run.node.attributes['audit']['attributes']).to eq({"my-inspec-attribute"=>"ok"})
+      expect(chef_run.node.attributes['audit']['attributes']).to eq({ 'my-inspec-attribute' => 'ok' })
     end
-    it "should contain the inspec attributes in the run_state" do
-      expect(chef_run.node.run_state['audit_attributes']).to eq({"my-inspec-attribute"=>"ok"})
+    it 'should contain the inspec attributes in the run_state' do
+      expect(chef_run.node.run_state['audit_attributes']).to eq({ 'my-inspec-attribute' => 'ok' })
     end
     it 'should not raise an exception' do
       expect { chef_run }.to_not raise_error
@@ -203,8 +203,8 @@ describe 'audit::default' do
     it 'should not contain the audit attributes after converge' do
       expect(chef_run.node.attributes['audit']['attributes']).to eq(nil)
     end
-    it "should contain the inspec attributes in the run_state" do
-      expect(chef_run.node.run_state['audit_attributes']).to eq({"my-inspec-attribute"=>"ok"})
+    it 'should contain the inspec attributes in the run_state' do
+      expect(chef_run.node.run_state['audit_attributes']).to eq({ 'my-inspec-attribute' => 'ok' })
     end
     it 'should not raise an exception' do
       expect { chef_run }.to_not raise_error


### PR DESCRIPTION
Introducing a new cookbook attribute `['audit']['attributes_save']` to remove `['audit']['attributes']` from the node object if needed.

Thank you @trickyearlobe for the feedback!

Opening the PR for now while working on tests