### PR TITLE
Restore style, unit and chefspec testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ before_install:
 matrix:
   include:
   - rvm: 2.6.3
+    script: rake
+  - rvm: 2.6.3
     script: rake $SUITE
     env: SUITE=test:integration OS='default-centos-7'
   - rvm: 2.6.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ services:
 
 before_install:
 - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+- CHEF_LICENSE="accept-no-persist" sudo chef gem install webmock
 - eval "$(chef shell-init bash)"
 - chef --version
 - cookstyle --version
@@ -27,8 +28,10 @@ before_install:
 
 matrix:
   include:
+  # Run the style, unit and chefspec tests
   - rvm: 2.6.3
     script: rake
+  # Run integration tests with test-kitchen
   - rvm: 2.6.3
     script: rake $SUITE
     env: SUITE=test:integration OS='default-centos-7'

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -17,7 +17,7 @@ module ReportHelpers
   # Returns the node's uuid
   def entity_uuid
     # the Chef::DataCollector::Messages API here is Chef < 15.0 backcompat and can be removed when Chef 14.x is no longer supported
-    node[:chef_guid] || defined?(Chef::DataCollector::Messages) && Chef::DataCollector::Messages.node_uuid
+    node['chef_guid'] || defined?(Chef::DataCollector::Messages) && Chef::DataCollector::Messages.node_uuid
   end
 
   # Convert the strings in the profile definitions into symbols for handling

--- a/libraries/reporters/cs_automate.rb
+++ b/libraries/reporters/cs_automate.rb
@@ -21,7 +21,7 @@ module Reporter
       @policy_group      = opts[:node_info][:policy_group]
       @policy_name       = opts[:node_info][:policy_name]
       @source_fqdn       = opts[:node_info][:source_fqdn]
-      @organization_name  = opts[:node_info][:organization_name]
+      @organization_name = opts[:node_info][:organization_name]
       @ipaddress         = opts[:node_info][:ipaddress]
       @fqdn              = opts[:node_info][:fqdn]
     end

--- a/resources/inspec_gem.rb
+++ b/resources/inspec_gem.rb
@@ -35,7 +35,7 @@ action :install do
       install_inspec_gem(version: new_resource.version, source: new_resource.source)
     end
   elsif new_resource.version.nil?
-    Chef::Log.info("inspec_gem: not installing Chef-InSpec. No Chef-Inspec version specified")
+    Chef::Log.info('inspec_gem: not installing Chef-InSpec. No Chef-Inspec version specified')
   elsif !compatible_version
     Chef::Log.info("inspec_gem: not installing Chef-InSpec. Requested version #{new_resource.version} is not compatible with chef-client #{Chef::VERSION}")
   end
@@ -80,12 +80,12 @@ action_class do
     return true if gem_version.nil?
 
     requirement = if chef_15?
-      # Chef-15 requires train 2.0 which was added in Inspec 4
-      Gem::Requirement.new('>= 4')
-    else
-      # min version required to run the audit handler
-      Gem::Requirement.new(['>= 1.25.1'])
-    end
+                    # Chef-15 requires train 2.0 which was added in Inspec 4
+                    Gem::Requirement.new('>= 4')
+                  else
+                    # min version required to run the audit handler
+                    Gem::Requirement.new(['>= 1.25.1'])
+                  end
 
     requirement.satisfied_by?(Gem::Version.new(gem_version))
   end

--- a/spec/data/mock.rb
+++ b/spec/data/mock.rb
@@ -10,7 +10,7 @@ class MockData
       organization_name: 'test_org',
       source_fqdn: 'api.chef.io',
       ipaddress: '192.168.56.33',
-      fqdn: 'lb1.prod.example.com'
+      fqdn: 'lb1.prod.example.com',
     }
   end
 

--- a/spec/unit/libraries/automate_spec.rb
+++ b/spec/unit/libraries/automate_spec.rb
@@ -70,13 +70,13 @@ describe 'Reporter::ChefAutomate methods' do
                                   "roles": %w(base_linux apache_linux),
                                   "recipes": ['some_cookbook::some_recipe', 'some_cookbook'],
                                   "report_uuid": '3f0536f7-3361-4bca-ae53-b45118dceb5d',
-                                  "source_fqdn": "api.chef.io",
-                                  "organization_name": "test_org",
-                                  "policy_group": "test_policy_group",
-                                  "policy_name": "test_policy_name",
-                                  "chef_tags": ["mylinux", "my.tag", "some=tag"],
-                                  "ipaddress": "192.168.56.33",
-                                  "fqdn": "lb1.prod.example.com",
+                                  "source_fqdn": 'api.chef.io',
+                                  "organization_name": 'test_org',
+                                  "policy_group": 'test_policy_group',
+                                  "policy_name": 'test_policy_name',
+                                  "chef_tags": ['mylinux', 'my.tag', 'some=tag'],
+                                  "ipaddress": '192.168.56.33',
+                                  "fqdn": 'lb1.prod.example.com',
       }
 
     opts = {

--- a/spec/unit/libraries/cs_automate_spec.rb
+++ b/spec/unit/libraries/cs_automate_spec.rb
@@ -56,13 +56,13 @@ describe 'Reporter::ChefServerAutomate methods' do
                                   "roles": %w(base_linux apache_linux),
                                   "recipes": ['some_cookbook::some_recipe', 'some_cookbook'],
                                   "report_uuid": '3f0536f7-3361-4bca-ae53-b45118dceb5d',
-                                  "source_fqdn": "api.chef.io",
-                                  "organization_name": "test_org",
-                                  "policy_group": "test_policy_group",
-                                  "policy_name": "test_policy_name",
-                                  "chef_tags": ["mylinux", "my.tag", "some=tag"],
-                                  "ipaddress": "192.168.56.33",
-                                  "fqdn": "lb1.prod.example.com",
+                                  "source_fqdn": 'api.chef.io',
+                                  "organization_name": 'test_org',
+                                  "policy_group": 'test_policy_group',
+                                  "policy_name": 'test_policy_name',
+                                  "chef_tags": ['mylinux', 'my.tag', 'some=tag'],
+                                  "ipaddress": '192.168.56.33',
+                                  "fqdn": 'lb1.prod.example.com',
       }
 
     opts = {

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -175,20 +175,4 @@ describe 'audit::default' do
       expect { chef_run }.to_not raise_error
     end
   end
-
-  context 'when audit_mode is enabled' do
-    let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.9')
-      runner.node.override['audit']['collector'] = 'json-file'
-      runner.node.override['audit']['profiles'] = [
-        { 'name': 'linux', 'compliance': 'base/linux' },
-      ]
-      Chef::Config[:audit_mode] = :enabled
-      runner.converge(described_recipe)
-    end
-
-    it 'raises an exception' do
-      expect { chef_run }.to raise_error(RuntimeError)
-    end
-  end
 end

--- a/spec/unit/report/audit_report_spec.rb
+++ b/spec/unit/report/audit_report_spec.rb
@@ -150,7 +150,7 @@ describe 'Chef::Handler::AuditReport methods' do
       # we cirumwent the default load mechanisms, therefore we have to require inspec
       require 'inspec'
       report = @audit_report.call(opts, profiles)
-      expected_report = /^.*version.*profiles.*controls.*statistics.*duration.*/
+      expected_report = /^.*profiles.*controls.*version.*statistics.*duration.*controls.*/
       expect(report.to_json).to match(expected_report)
     end
     it 'given a profile, returns a json-min report' do

--- a/spec/unit/report/fetcher_spec.rb
+++ b/spec/unit/report/fetcher_spec.rb
@@ -47,7 +47,7 @@ describe ChefServer::Fetcher do
     it 'should resolve a target' do
       mynode.default['audit']['fetcher'] = nil
       res = ChefServer::Fetcher.resolve(myprofile)
-      expect(res.target).to eq(URI(myprofile))
+      expect(res.target).to eq(myprofile)
     end
 
     it 'should add /compliance URL prefix if needed' do
@@ -70,7 +70,7 @@ describe ChefServer::Fetcher do
     it 'should resolve a target with a version' do
       mynode.default['audit']['fetcher'] = nil
       res = ChefServer::Fetcher.resolve(profile_hash)
-      expect(res.target.request_uri).to eq(profile_hash_target)
+      expect(res.target).to eq("http://127.0.0.1:8889#{profile_hash_target}")
     end
   end
 


### PR DESCRIPTION
Adding back style, unit and chefspec testing in Travis after being accidentally removed in a previous PR.