### PR TITLE
bump chef infra client requirement to 12.20 to match metadata. Obviou…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `audit` cookbook supports a number of different reporters and fetchers which
 
 ### Chef
 
-- Chef Client >=12.5.1
+- Chef Client >=12.20
 
 ### Support Matrix
 


### PR DESCRIPTION
### Description

Corrects the README to match the chef-client version requirement listed in the metadata

### Issues Resolved

#338 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Obvious fix.