### PR TITLE
Ignore inspec_version for chef client >= 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Also beginning with version 3.x of the `audit` cookbook, the default version of 
 
 To install a different version of the InSpec gem, or to force installation of the gem, set the `node['audit']['inspec_version']` attribute to the version you wish to be installed.
 
+**Starting with Chef Infra Client 15, only the embedded InSpec gem can be used and the `inspec_version` attribute will be ignored.**
+
 Note on AIX Support:
 
  * InSpec is only supported via the bundled InSpec gem shipped with version >= 13 of the chef-client package.
@@ -129,9 +131,6 @@ Once the cookbook is available in Chef Server, you need to add the `audit::defau
 
 ```ruby
 default['audit']['reporter'] = 'chef-server-compliance'
-
-# Omit this to use the latest InSpec
-default['audit']['inspec_version'] = '1.29.0'
 
 # You may use an array of hashes (shown here) or hash of hashes (shown below)
 default['audit']['profiles'].push(
@@ -620,14 +619,15 @@ rspec ./spec/unit/libraries/automate_spec.rb
 
 Releasing a new cookbook version:
 
-1. version bump the metadata.rb and updated changelog (`bundle exec rake changelog`)
-2. Get your changes merged into master
-3. Go to the `audit` cookbook directory and pull from master
-4. Run `bundle install`
-5. Use stove to publish the cookbook(including git version tag). You must point to the private key of your hosted chef user. For example:
+1. Install changelog gem: `chef gem install github_changelog_generator`
+2. version bump the metadata.rb and updated changelog (`rake changelog`)
+3. Get your changes merged into master
+4. Go to the `audit` cookbook directory and pull from master
+5. Run `bundle install`
+6. Use stove to publish the cookbook(including git version tag). You must point to the private key of your hosted chef user. For example:
 
   ```
-  bundle exec stove --username apop --key ~/git/chef-repo/.chef/apop.pem
+  stove --username apop --key ~/git/chef-repo/.chef/apop.pem
   ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ The `audit` cookbook supports a number of different reporters and fetchers which
 |   > 1.1.23                 |   ≥ 0.22.1        |   = 0.8.0                 |
 |   ≥ 1.6.8                  |   ≥ 1.2.0         |   > 1.0.2                 |
 
-#### Chef Client
+#### Chef Infra Client
 
 | Chef Client                | Audit Cookbook version    |
 |----------------------------|---------------------------|
-|   >= 15.0.293              |   >= 7.7.0                |
+|   >= 15                    |   >= 8.0.0                |
 
 Note:
 When used with Chef Client 15 and above, the Audit cookbook _must_ be >= 7.7.0. Otherwise, you will see the following failure.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# controls inspec gem version to install
-# example values: '1.1.0', 'latest'
+# Controls the inspec gem version to install and execution. Example values: '1.1.0', 'latest'
+# Starting with Chef Infra Client 15, only the embedded InSpec gem can be used and this attribute will be ignored
 default['audit']['inspec_version'] = nil
 
 # sets URI to alternate gem source

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting its results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '7.8.0'
+version '8.0.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -5,6 +5,7 @@
 
 require 'spec_helper'
 require_relative '../../../libraries/helper'
+require_relative '../../../files/default/handler/audit_report'
 
 describe ReportHelpers do
   let(:helpers) { Class.new { extend ReportHelpers } }


### PR DESCRIPTION
The `default['audit']['inspec_version']` attribute has been added to the cookbook before chef-client came with an embedded InSpec gem.

Currently the `inspec_gem` resource of the `audit` cookbook is uninstalling the existing versions of InSpec and installing the one specified by the `inspec_version` attribute. With the release of Chef Infra Client 15, this breaks `/opt/chef/bin/chef-client` as can be seen here:

```
[root@myapache ~]# chef-client
Traceback (most recent call last):
    3: from /usr/bin/chef-client:59:in `<main>'
    2: from /opt/chef/embedded/lib/ruby/2.6.0/rubygems/core_ext/kernel_gem.rb:65:in `gem'
    1: from /opt/chef/embedded/lib/ruby/2.6.0/rubygems/dependency.rb:323:in `to_spec'
/opt/chef/embedded/lib/ruby/2.6.0/rubygems/dependency.rb:313:in `to_specs': Could not find 'inspec-core' (= 4.3.2) - did find: [inspec-core-4.6.4]
```

I reproduced this issue by converging a node with `Chef Infra Client 15.0.300` and the `audit` cookbook with attribute `inspec_version` set to `4.6.4`. The `inspec_gem` resource uninstalled the embedded `inspec-core` version `4.3.2` and installed `4.6.4`.

With this PR the audit cookbook ignores the `inspec_version` attribute when Chef Infra Client version 15+ is detected and uses the embedded InSpec gem for the scan. Not breaking chef-client at this moment is more important than using a specific version of InSpec for the scan.

