### PR TITLE
Implement an 'audit' reporter that will terminate Chef Client runs on profile failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ The `audit-enforcer` enables you to enforce compliance with executed profiles. I
 default['audit']['reporter'] = 'audit-enforcer'
 ```
 
-Note that detection of non-compliance will immediately terminate the Chef Client run. If you specify [multiple reporters](#multiple-reporters), place the `audit-enforcer` at the end of the list to 
+Note that detection of non-compliance will immediately terminate the Chef Client run. If you specify [multiple reporters](#multiple-reporters), place the `audit-enforcer` at the end of the list, allowing the other reporters to generate their output prior to run termination.
 
 #### Multiple Reporters
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,16 @@ the Chef log:
 [2017-08-29T00:22:10+00:00] INFO: Report handlers complete
 ```
 
+#### Enforce compliance with executed profiles
+
+The `audit-enforcer` enables you to enforce compliance with executed profiles. If the system under test is determined to be non-compliant, this reporter will raise an error and fail the Chef Client run. To activate compliance enforcement, set the `reporter` attribute to 'audit-enforcer':
+
+```ruby
+default['audit']['reporter'] = 'audit-enforcer'
+```
+
+Note that detection of non-compliance will immediately terminate the Chef Client run. If you specify [multiple reporters](#multiple-reporters), place the `audit-enforcer` at the end of the list to 
+
 #### Multiple Reporters
 
 To enable multiple reporters, simply define multiple reporters with all the necessary information

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -295,6 +295,8 @@ class Chef
           path = node['audit']['json_file']['location']
           Chef::Log.info "Writing report to #{path}"
           Reporter::JsonFile.new(file: path).send_report(report)
+        elsif reporter == 'audit-enforcer'
+          Reporter::AuditEnforcer.new.send_report(report)
         else
           Chef::Log.warn "#{reporter} is not a supported InSpec report collector"
         end

--- a/libraries/reporters/audit-enforcer.rb
+++ b/libraries/reporters/audit-enforcer.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+
+module Reporter
+  #
+  # Used to raise an error on conformance failure
+  #
+  class AuditEnforcer
+    def send_report(report)
+      # iterate over each profile and control
+      report[:profiles].each do |profile|
+        unless profile[:controls].nil?
+          profile[:controls].each do |control|
+            next if control[:results].nil?
+            control[:results].each do |result|
+              fail "Audit #{control[:id]} has failed. Aborting chef-client run." if result[:status] == 'failed'
+            end
+          end
+        end
+      end
+      true
+    end
+  end
+end

--- a/libraries/reporters/audit-enforcer.rb
+++ b/libraries/reporters/audit-enforcer.rb
@@ -8,12 +8,11 @@ module Reporter
     def send_report(report)
       # iterate over each profile and control
       report[:profiles].each do |profile|
-        unless profile[:controls].nil?
-          profile[:controls].each do |control|
-            next if control[:results].nil?
-            control[:results].each do |result|
-              fail "Audit #{control[:id]} has failed. Aborting chef-client run." if result[:status] == 'failed'
-            end
+        next if profile[:controls].nil?
+        profile[:controls].each do |control|
+          next if control[:results].nil?
+          control[:results].each do |result|
+            raise "Audit #{control[:id]} has failed. Aborting chef-client run." if result[:status] == 'failed'
           end
         end
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting their results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '7.9.0'
+version '8.1.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,9 +3,9 @@ name 'audit'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
-description 'Allows for fetching and executing compliance profiles, and reporting its results'
+description 'Allows for fetching and executing compliance profiles, and reporting their results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '7.8.0'
+version '7.9.0'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'

--- a/spec/unit/libraries/audit_enforcer_spec.rb
+++ b/spec/unit/libraries/audit_enforcer_spec.rb
@@ -1,0 +1,54 @@
+# encoding: utf-8
+#
+# Cookbook Name:: audit
+# Spec:: automate_spec
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require_relative '../../../libraries/reporters/audit-enforcer'
+
+describe 'Reporter::ChefAutomate methods' do
+  before :each do
+    @min_report = {
+      "profiles": [
+        {
+          "controls": [
+            { "id": "c1", "results": [{ "status": 'passed' }] },
+            { "id": "c2", "results": [{ "status": 'passed' }] },
+          ],
+        },
+      ],
+    }
+    @automate = Reporter::AuditEnforcer.new()
+  end
+
+  it 'is not raising error for a successful InSpec report' do
+    expect(@automate.send_report(@min_report)).to eq(true)
+  end
+
+  it 'is not raising error for an InSpec report with no controls' do
+    expect(@automate.send_report({"profiles": [{"name": "empty"}]})).to eq(true)
+  end
+
+  it 'is not raising error for an InSpec report with controls but no results' do
+    expect(@automate.send_report({"profiles": [{ "controls": [{"id": "empty"}]}]})).to eq(true)
+  end
+
+  it 'raises an error for a failed InSpec report' do
+    @min_report[:profiles][0][:controls][1][:results][0][:status] = 'failed'
+    expect{ @automate.send_report(@min_report) }.to raise_error('Audit c2 has failed. Aborting chef-client run.')
+  end
+end

--- a/spec/unit/libraries/audit_enforcer_spec.rb
+++ b/spec/unit/libraries/audit_enforcer_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Cookbook Name:: audit
 # Spec:: automate_spec
@@ -26,13 +25,13 @@ describe 'Reporter::ChefAutomate methods' do
       "profiles": [
         {
           "controls": [
-            { "id": "c1", "results": [{ "status": 'passed' }] },
-            { "id": "c2", "results": [{ "status": 'passed' }] },
+            { "id": 'c1', "results": [{ "status": 'passed' }] },
+            { "id": 'c2', "results": [{ "status": 'passed' }] },
           ],
         },
       ],
     }
-    @automate = Reporter::AuditEnforcer.new()
+    @automate = Reporter::AuditEnforcer.new
   end
 
   it 'is not raising error for a successful InSpec report' do
@@ -40,15 +39,15 @@ describe 'Reporter::ChefAutomate methods' do
   end
 
   it 'is not raising error for an InSpec report with no controls' do
-    expect(@automate.send_report({"profiles": [{"name": "empty"}]})).to eq(true)
+    expect(@automate.send_report({ "profiles": [{ "name": 'empty' }] })).to eq(true)
   end
 
   it 'is not raising error for an InSpec report with controls but no results' do
-    expect(@automate.send_report({"profiles": [{ "controls": [{"id": "empty"}]}]})).to eq(true)
+    expect(@automate.send_report({ "profiles": [{ "controls": [{ "id": 'empty' }] }] })).to eq(true)
   end
 
   it 'raises an error for a failed InSpec report' do
     @min_report[:profiles][0][:controls][1][:results][0][:status] = 'failed'
-    expect{ @automate.send_report(@min_report) }.to raise_error('Audit c2 has failed. Aborting chef-client run.')
+    expect { @automate.send_report(@min_report) }.to raise_error('Audit c2 has failed. Aborting chef-client run.')
   end
 end


### PR DESCRIPTION
### Description

This pull request implements an `audit enforcer` reporter to replace the `fail_if_any_audits_failed` feature that was removed a while ago.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
