### PR TITLE
Add and check for custom exception to propagate audit failures

### DIFF
--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -102,7 +102,7 @@ class Chef
         Chef::Log.error("Report handler #{self.class.name} raised #{e.inspect}")
         Array(e.backtrace).each { |line| Chef::Log.error(line) }
         # force a chef-client exception if user requested it
-        throw e if node['audit']['fail_if_not_present']
+        throw e if e.is_a?(AuditEnforcer::ControlFailure) || node['audit']['fail_if_not_present']
       ensure
         @run_status = nil
       end

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -102,7 +102,7 @@ class Chef
         Chef::Log.error("Report handler #{self.class.name} raised #{e.inspect}")
         Array(e.backtrace).each { |line| Chef::Log.error(line) }
         # force a chef-client exception if user requested it
-        throw e if e.is_a?(AuditEnforcer::ControlFailure) || node['audit']['fail_if_not_present']
+        throw e if e.is_a?(Reporter::AuditEnforcer::ControlFailure) || node['audit']['fail_if_not_present']
       ensure
         @run_status = nil
       end

--- a/libraries/reporters/audit-enforcer.rb
+++ b/libraries/reporters/audit-enforcer.rb
@@ -5,10 +5,10 @@ module Reporter
   # Used to raise an error on conformance failure
   #
   class AuditEnforcer
-  
+
     class AuditControlFailure < StandardError
     end
-    
+
     def send_report(report)
       # iterate over each profile and control
       report[:profiles].each do |profile|

--- a/libraries/reporters/audit-enforcer.rb
+++ b/libraries/reporters/audit-enforcer.rb
@@ -5,7 +5,6 @@ module Reporter
   # Used to raise an error on conformance failure
   #
   class AuditEnforcer
-
     class AuditControlFailure < StandardError
     end
 

--- a/libraries/reporters/audit-enforcer.rb
+++ b/libraries/reporters/audit-enforcer.rb
@@ -6,7 +6,8 @@ module Reporter
   #
   class AuditEnforcer
   
-    class AuditControlFailure < StandardError end
+    class AuditControlFailure < StandardError
+    end
     
     def send_report(report)
       # iterate over each profile and control

--- a/libraries/reporters/audit-enforcer.rb
+++ b/libraries/reporters/audit-enforcer.rb
@@ -5,6 +5,9 @@ module Reporter
   # Used to raise an error on conformance failure
   #
   class AuditEnforcer
+  
+    class AuditControlFailure < StandardError end
+    
     def send_report(report)
       # iterate over each profile and control
       report[:profiles].each do |profile|
@@ -12,7 +15,7 @@ module Reporter
         profile[:controls].each do |control|
           next if control[:results].nil?
           control[:results].each do |result|
-            raise "Audit #{control[:id]} has failed. Aborting chef-client run." if result[:status] == 'failed'
+            raise AuditControlFailure, "Audit #{control[:id]} has failed. Aborting chef-client run." if result[:status] == 'failed'
           end
         end
       end

--- a/libraries/reporters/audit-enforcer.rb
+++ b/libraries/reporters/audit-enforcer.rb
@@ -5,8 +5,7 @@ module Reporter
   # Used to raise an error on conformance failure
   #
   class AuditEnforcer
-    class AuditControlFailure < StandardError
-    end
+    class ControlFailure < StandardError; end
 
     def send_report(report)
       # iterate over each profile and control
@@ -15,7 +14,7 @@ module Reporter
         profile[:controls].each do |control|
           next if control[:results].nil?
           control[:results].each do |result|
-            raise AuditControlFailure, "Audit #{control[:id]} has failed. Aborting chef-client run." if result[:status] == 'failed'
+            raise ControlFailure, "Audit #{control[:id]} has failed. Aborting chef-client run." if result[:status] == 'failed'
           end
         end
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting their results'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '8.1.0'
+version '8.1.1'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'

--- a/spec/unit/libraries/audit_enforcer_spec.rb
+++ b/spec/unit/libraries/audit_enforcer_spec.rb
@@ -48,6 +48,6 @@ describe 'Reporter::ChefAutomate methods' do
 
   it 'raises an error for a failed InSpec report' do
     @min_report[:profiles][0][:controls][1][:results][0][:status] = 'failed'
-    expect { @automate.send_report(@min_report) }.to raise_error(AuditControlFailure, 'Audit c2 has failed. Aborting chef-client run.')
+    expect { @automate.send_report(@min_report) }.to raise_error(AuditEnforcer::ControlFailure, 'Audit c2 has failed. Aborting chef-client run.')
   end
 end

--- a/spec/unit/libraries/audit_enforcer_spec.rb
+++ b/spec/unit/libraries/audit_enforcer_spec.rb
@@ -48,6 +48,6 @@ describe 'Reporter::ChefAutomate methods' do
 
   it 'raises an error for a failed InSpec report' do
     @min_report[:profiles][0][:controls][1][:results][0][:status] = 'failed'
-    expect { @automate.send_report(@min_report) }.to raise_error('Audit c2 has failed. Aborting chef-client run.')
+    expect { @automate.send_report(@min_report) }.to raise_error(AuditControlFailure, 'Audit c2 has failed. Aborting chef-client run.')
   end
 end

--- a/spec/unit/libraries/audit_enforcer_spec.rb
+++ b/spec/unit/libraries/audit_enforcer_spec.rb
@@ -48,6 +48,6 @@ describe 'Reporter::ChefAutomate methods' do
 
   it 'raises an error for a failed InSpec report' do
     @min_report[:profiles][0][:controls][1][:results][0][:status] = 'failed'
-    expect { @automate.send_report(@min_report) }.to raise_error(AuditEnforcer::ControlFailure, 'Audit c2 has failed. Aborting chef-client run.')
+    expect { @automate.send_report(@min_report) }.to raise_error(Reporter::AuditEnforcer::ControlFailure, 'Audit c2 has failed. Aborting chef-client run.')
   end
 end


### PR DESCRIPTION
Signed-off-by: Scott Babcock <scoba@hotmail.com>

### Description

Adding a custom exception to eliminate the need to set an attribute to propagate audit control failures.

### Issues Resolved



### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
