### PR TITLE
Detect 429 & 413 and append an additional message

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -55,6 +55,10 @@ module ReportHelpers
       Chef::Log.error 'Auth issue: see audit cookbook TROUBLESHOOTING.md'
     when /404/
       Chef::Log.error 'Object does not exist on remote server.'
+    when /413/
+      Chef::Log.error 'You most likely hit the erchef request size in Chef Server that defaults to ~2MB. To increase this limit see audit cookbook TROUBLESHOOTING.md OR https://docs.chef.io/config_rb_server.html'
+    when /429/
+      Chef::Log.error "This error typically means the data sent was larger than Automate's limit (4 MB). Run InSpec locally to identify any controls producing large diffs."
     end
     msg = "Received HTTP error #{code}"
     Chef::Log.error msg


### PR DESCRIPTION

### Description

In order to provide better user experince detect know errors 413 (`Request Entity Too Large`) & 413 (`Too Many Requests`) and append additional info. so that the user can easily track and perform adequate actions.

- 413:
```
You most likely hit the erchef request size in Chef Server that defaults to ~2MB. To increase this limit see audit cookbook TROUBLESHOOTING.md OR https://docs.chef.io/config_rb_server.html
```

- 429: 

```
This error typically means the data sent was larger than Automate's limit (4 MB). Run InSpec locally to identify any controls producing large diffs.
```

### Issues Resolved

Fixes https://github.com/chef-cookbooks/audit/issues/384

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>