### PR TITLE
Add waiver-file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ default['audit']['attributes'] = {
 }
 ```
 
+#### Waivers
+
+You can use Chef InSpec's [Waiver Feature](https://www.inspec.io/docs/reference/waivers/) to mark individual failing controls as being administratively accepted, either on a temporary or permanent basis. Prepare a waiver YAML file, and use your Chef Infra cookbooks to deliver the file to your converging node (for example, using [cookbook_file](https://docs.chef.io/resource_cookbook_file.html) or [remote_file](https://docs.chef.io/resource_remote_file.html)). Then set the attribute `default['audit']['waiver_file']` to the location of the waiver file on the local node, and Chef InSpec will apply the waivers.
+
 ### Reporting
 
 #### Reporting to Chef Automate via Chef Server

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -80,6 +80,10 @@ default['audit']['attributes_save'] = true
 # named `chef_node`
 default['audit']['chef_node_attribute_enabled'] = false
 
+# Set this to the path of a YAML waiver file you wish to apply
+# See https://www.inspec.io/docs/reference/waivers/
+default['audit']['waiver_file'] = nil
+
 # The location of the json-file output:
 # <chef_cache_path>/cookbooks/audit/inspec-<YYYYMMDDHHMMSS>.json
 default['audit']['json_file']['location'] =

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -147,6 +147,8 @@ class Chef
       def get_opts(reporter, quiet, attributes)
         output = quiet ? ::File::NULL : $stdout
         Chef::Log.debug "Reporter is [#{reporter}]"
+        # You can pass nil (no waiver files), one file, or an array. InSpec expects an Array regardless.
+        waivers = node['audit']['waiver_file'].nil? ? [] : Array(node['audit']['waiver_file'])
         opts = {
           'report' => true,
           'format' => reporter, # For compatibility with older versions of inspec. TODO: Remove this line from Q2 2019
@@ -155,6 +157,7 @@ class Chef
           'logger' => Chef::Log, # Use chef-client log level for inspec run,
           backend_cache: node['audit']['inspec_backend_cache'],
           attributes: attributes,
+          waiver_file: waivers,
         }
         opts
       end

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -148,7 +148,7 @@ class Chef
         output = quiet ? ::File::NULL : $stdout
         Chef::Log.debug "Reporter is [#{reporter}]"
         # You can pass nil (no waiver files), one file, or an array. InSpec expects an Array regardless.
-        waivers = node['audit']['waiver_file'].nil? ? [] : Array(node['audit']['waiver_file'])
+        waivers = Array(node['audit']['waiver_file'])
         opts = {
           'report' => true,
           'format' => reporter, # For compatibility with older versions of inspec. TODO: Remove this line from Q2 2019

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -208,3 +208,17 @@ suites:
             url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip
           ssh-baseline:
             supermarket: dev-sec/ssh-baseline
+  - name: waivers
+    run_list:
+      - recipe[test_helper::setup]
+      - recipe[test_helper::setup_waiver_fixture]
+      - recipe[audit::default]
+    attributes:
+      audit:
+        reporter: json-file
+        json_file:
+          location: <%= File.join('/tmp', Time.now.utc.strftime('inspec-%Y%m%d%H%M%S.json')) %>
+        waiver_file: <%= File.join('/tmp', 'waivers-fixture', 'waivers', 'waivers.yaml') %>
+        profiles:
+          waiver-test-profile:
+            path: <%= File.join('/tmp', 'waivers-fixture') %>

--- a/test/cookbooks/test_helper/files/waivers-fixture/controls/waiver-check.rb
+++ b/test/cookbooks/test_helper/files/waivers-fixture/controls/waiver-check.rb
@@ -1,0 +1,16 @@
+
+# Some of these controls are waivered by the file waivers/waivers.yaml
+
+# control-01 is normal, should pass
+control "control-01" do
+  describe "the expected value" do
+    it { should cmp "the expected value" }
+  end
+end
+
+# control-02 is permanently waivered, should be skipped
+control "control-02" do
+  describe "the expected value" do
+    it { should cmp "the expected value" }
+  end
+end

--- a/test/cookbooks/test_helper/files/waivers-fixture/inspec.yml
+++ b/test/cookbooks/test_helper/files/waivers-fixture/inspec.yml
@@ -1,0 +1,6 @@
+name: waivers-fixture
+license: Apache-2.0
+summary: A simple profile to verify waiver functionality under audit cookbook
+version: 0.1.0
+supports:
+  platform: os

--- a/test/cookbooks/test_helper/files/waivers-fixture/waivers/waivers.yaml
+++ b/test/cookbooks/test_helper/files/waivers-fixture/waivers/waivers.yaml
@@ -1,0 +1,4 @@
+---
+control-02:
+  justification: It must be waivered for this test
+  run: false

--- a/test/cookbooks/test_helper/recipes/setup_waiver_fixture.rb
+++ b/test/cookbooks/test_helper/recipes/setup_waiver_fixture.rb
@@ -1,0 +1,19 @@
+
+[
+  "controls",
+  "waivers",
+].each do |subdir|
+  directory "#{node["audit"]["profiles"]["waiver-test-profile"]["path"]}/#{subdir}" do
+    recursive true
+  end
+end
+
+[
+  "inspec.yml",
+  "controls/waiver-check.rb",
+  "waivers/waivers.yaml",
+].each do |file|
+  cookbook_file "#{node["audit"]["profiles"]["waiver-test-profile"]["path"]}/#{file}" do
+    source "waivers-fixture/#{file}"
+  end
+end

--- a/test/integration/waivers/default.rb
+++ b/test/integration/waivers/default.rb
@@ -1,0 +1,18 @@
+# get most recent json-file output
+json_file = command('ls -t /tmp/inspec-*.json').stdout.lines.first.chomp
+controls = json(json_file).profiles.first['controls']
+
+# The test fixture has two controls - the first should pass,
+# the second should be a skip with a waiver justification
+
+control "the unwaivered control" do
+  describe controls[0]['results'][0]['status'] do
+    it { should cmp "passed" }
+  end
+end
+
+control "the waivered control" do
+  describe controls[1]['results'][0]['status'] do
+    it { should cmp "skipped" }
+  end
+end


### PR DESCRIPTION
### Description

Adds an attribute that allows the user to specify a Waiver file.

A new kitchen-dokken test suite is provided, along with a test profile.

Note that at least the "inspec-attributes" suite was found to be broken at this time - no attempt was made to fix it on this PR, that's coming on another.

TESTING NOTE: 

The Audit cookbook should be tested with env vars:
```
KITCHEN_YAML=kitchen.dokken.yaml
CHEF_VERSION=15.6.10
```

A typical kitchen scenario might be `waivers-ubuntu-1804`.

Note that the waivers tests will **fail** unless the chef version is specified as above or higher, for the following chain of reasons:
- The audit cookbook, when running chef 15, ignores any requested InSpec version, and ALWAYS uses the gem version included with the Chef Infra Client.
- For chef 15, that appears to resolve to chef 15.4.45, which includes InSpec 4.17.17
- 4.17.17 included waiver support **but** placed the waiver reporter data on a per-result (not per-control) basis - that was changed in release 4.18.0
- The tests have been written against the long-term (per-control) behavior, and thus fail

This chain can be verified:

```
kitchen converge waivers-ubuntu-1804
kitchen login waivers-ubuntu-1804
# ls -t /tmp/inspec-*.json # note most recent file
# more inspec-whatever.json # note per-result, not per-control output
```

Testing against Chef Infra 15.6.10 or later resolves that issue.

### Issues Resolved

Closes #397 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
