### PR TITLE
[DO NOT MERGE] Rename InSpec Attributes to Inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ default['audit']['profiles']['ssh2'] = {
 }
 ```
 
-#### Attributes
+#### Inputs
 
-You can also pass in [InSpec Attributes](https://www.inspec.io/docs/reference/profiles/) to your audit run. Do this by defining the attributes:
+You can also pass in [InSpec Inputs](https://www.inspec.io/docs/reference/inputs/) to your audit run. Do this by defining the attributes:
 
 ```ruby
-default['audit']['attributes'] = {
-  first_attribute: 'some value',
-  second_attribute: 'another value',
+default['audit']['inputs'] = {
+  first_input: 'some value',
+  second_input: 'another value',
 }
 ```
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,15 +70,15 @@ default['audit']['quiet'] = true
 # See README.md for details
 default['audit']['profiles'] = {}
 
-# Attributes used to run the given profiles
-default['audit']['attributes'] = {}
+# Inputs used to run the given profiles
+default['audit']['inputs'] = {} # TODO: legacy attribute support
 
-# Set this to false if you don't want ['audit']['attributes'] to be saved in the node object and stored in Chef Server or Automate. Useful if you are passing sensitive data to the inspec profile via the attributes.
-default['audit']['attributes_save'] = true
+# Set this to false if you don't want ['audit']['inputs'] to be saved in the node object and stored in Chef Server or Automate. Useful if you are passing sensitive data to the inspec profile via the attributes.
+default['audit']['inputs_save'] = true # TODO: legacy attribute support?
 
-# If enabled, a hash of the Chef "node" object will be sent to InSpec in an attribute
+# If enabled, a hash of the Chef "node" object will be sent to InSpec in an input
 # named `chef_node`
-default['audit']['chef_node_attribute_enabled'] = false
+default['audit']['chef_node_input_enabled'] = false # TODO: legacy attribute support?
 
 # The location of the json-file output:
 # <chef_cache_path>/cookbooks/audit/inspec-<YYYYMMDDHHMMSS>.json

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,7 +71,11 @@ default['audit']['quiet'] = true
 default['audit']['profiles'] = {}
 
 # Inputs used to run the given profiles
-default['audit']['inputs'] = {} # TODO: legacy attribute support
+default['audit']['inputs'] = {}
+# Inputs were formerly called attributes; this is provided for backwards
+# compatibility but will be merged into default['audit']['inputs'].
+# To be removed in a major version change.
+default['audit']['attributes'] = {}
 
 # Set this to false if you don't want ['audit']['inputs'] to be saved in the node object and stored in Chef Server or Automate. Useful if you are passing sensitive data to the inspec profile via the attributes.
 default['audit']['inputs_save'] = true # TODO: legacy attribute support?

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -47,10 +47,10 @@ class Chef
         quiet = node['audit']['quiet']
         fetcher = node['audit']['fetcher']
 
-        attributes = node.run_state['audit_attributes'].to_h
+        inputs = node.run_state['audit_inputs'].to_h
 
-        # add chef node data as an attribute if enabled
-        attributes['chef_node'] = chef_node_attribute_data if node['audit']['chef_node_attribute_enabled']
+        # add chef node data as an input if enabled
+        inputs['chef_node'] = chef_node_attribute_data if node['audit']['chef_node_input_enabled'] # TODO legacy option support
 
         # load inspec, supermarket bundle and compliance bundle
         load_needed_dependencies
@@ -76,7 +76,7 @@ class Chef
           end
 
           # return hash of opts to be used by runner
-          opts = get_opts(reporter_format, quiet, attributes)
+          opts = get_opts(reporter_format, quiet, inputs)
 
           # instantiate inspec runner with given options and run profiles; return report
           report = call(opts, profiles)
@@ -144,7 +144,7 @@ class Chef
         require 'chef-automate/fetcher'
       end
 
-      def get_opts(reporter, quiet, attributes)
+      def get_opts(reporter, quiet, inputs)
         output = quiet ? ::File::NULL : $stdout
         Chef::Log.debug "Reporter is [#{reporter}]"
         opts = {
@@ -154,7 +154,7 @@ class Chef
           'output' => output,
           'logger' => Chef::Log, # Use chef-client log level for inspec run,
           backend_cache: node['audit']['inspec_backend_cache'],
-          attributes: attributes,
+          inputs: inputs,
         }
         opts
       end

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -118,9 +118,9 @@ suites:
         json_file:
           location: <%= File.join('/tmp', Time.now.utc.strftime('inspec-%Y%m%d%H%M%S.json')) %>
         profiles:
-          demo:
-            url: https://github.com/adamleff/inspec-profile-chef-node-attributes/archive/master.tar.gz
-        chef_node_attribute_enabled: true
+          inspec-test-profile-chef-node-input:
+            url: https://github.com/inspec/inspec-test-profile-chef-node-input/archive/1.0.0.tar.gz
+        chef_node_input_enabled: true
   - name: chef-node-disabled
     run_list:
       - recipe[audit::default]
@@ -130,8 +130,8 @@ suites:
         json_file:
           location: <%= File.join('/tmp', Time.now.utc.strftime('inspec-%Y%m%d%H%M%S.json')) %>
         profiles:
-          demo:
-            url: https://github.com/adamleff/inspec-profile-chef-node-attributes/archive/master.tar.gz
+          inspec-test-profile-chef-node-input:
+            url: https://github.com/inspec/inspec-test-profile-chef-node-input/archive/1.0.0.tar.gz
   - name: missing-profile-no-fail
     run_list:
       - recipe[test_helper::setup]

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -109,6 +109,21 @@ suites:
             git: https://github.com/inspec/input-file-exists-profile.git
         inputs:
           test_file_path: /opt/kitchen/cache/file-exists.test
+  - name: inputs-legacy
+    run_list:
+      - recipe[test_helper::setup]
+      - recipe[test_helper::create_file]
+      - recipe[audit::default]
+    attributes:
+      audit:
+        reporter: json-file
+        json_file:
+          location: <%= File.join('/tmp', Time.now.utc.strftime('inspec-%Y%m%d%H%M%S.json')) %>
+        profiles:
+          input-file-exists-profile:
+            git: https://github.com/inspec/input-file-exists-profile.git
+        attributes: # Note legacy name for inputs
+          test_file_path: /opt/kitchen/cache/file-exists.test
   - name: chef-node-enabled
     run_list:
       - recipe[audit::default]

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -94,7 +94,7 @@ suites:
             url: https://github.com/dev-sec/tests-ssh-hardening/archive/master.zip
           - name: ssh-baseline
             supermarket: dev-sec/ssh-baseline
-  - name: inspec-attributes
+  - name: inputs
     run_list:
       - recipe[test_helper::setup]
       - recipe[test_helper::create_file]
@@ -105,10 +105,10 @@ suites:
         json_file:
           location: <%= File.join('/tmp', Time.now.utc.strftime('inspec-%Y%m%d%H%M%S.json')) %>
         profiles:
-          attribute-file-exists-profile:
-            git: https://github.com/mhedgpeth/attribute-file-exists-profile.git
-        attributes:
-          file: /opt/kitchen/cache/attribute-file-exists.test
+          input-file-exists-profile:
+            git: https://github.com/inspec/input-file-exists-profile.git
+        inputs:
+          test_file_path: /opt/kitchen/cache/file-exists.test
   - name: chef-node-enabled
     run_list:
       - recipe[audit::default]

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -119,7 +119,14 @@ module ReportHelpers
   # Copies ['audit']['inputs'] into run_state for the audit_handler to read them later
   # Deletes ['audit']['inputs'] if instructed by ['audit']['inputs_save']
   def copy_audit_inputs
-    node.run_state['audit_inputs'] = node['audit']['inputs']  # TODO legacy option
+    # Handle legacy option name
+    unless node['audit']['attributes'].empty?
+      Chef::Log.warn("node['audit']['attributes'] is deprecated - please use node['audit']['inputs']. Merging...")
+      node.default['audit']['inputs'].merge!(node['audit']['attributes'])
+      node.default['audit']['attributes'].clear
+    end
+
+    node.run_state['audit_inputs'] = node['audit']['inputs']
     node.rm('audit', 'inputs') unless node['audit']['inputs_save'] # TODO legacy option
   end
 

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -116,11 +116,11 @@ module ReportHelpers
     File.expand_path('../../files/default/handler', __FILE__)
   end
 
-  # Copies ['audit']['attributes'] into run_state for the audit_handler to read them later
-  # Deletes ['audit']['attributes'] if instructed by ['audit']['attributes_save']
-  def copy_audit_attributes
-    node.run_state['audit_attributes'] = node['audit']['attributes']
-    node.rm('audit', 'attributes') unless node['audit']['attributes_save']
+  # Copies ['audit']['inputs'] into run_state for the audit_handler to read them later
+  # Deletes ['audit']['inputs'] if instructed by ['audit']['inputs_save']
+  def copy_audit_inputs
+    node.run_state['audit_inputs'] = node['audit']['inputs']  # TODO legacy option
+    node.rm('audit', 'inputs') unless node['audit']['inputs_save'] # TODO legacy option
   end
 
   def load_audit_handler

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,5 +30,5 @@ end
 include_recipe 'audit::inspec'
 
 # Call helper methods located in libraries/helper.rb
-copy_audit_attributes
+copy_audit_inputs
 load_audit_handler

--- a/test/cookbooks/test_helper/recipes/create_file.rb
+++ b/test/cookbooks/test_helper/recipes/create_file.rb
@@ -1,5 +1,5 @@
 # ensures that the file defined by attributes exists, so its associated profile will pass
 
-file node['audit']['attributes']['file'] do
+file node['audit']['inputs']['test_file_path'] do
   action :create
 end

--- a/test/cookbooks/test_helper/recipes/create_file.rb
+++ b/test/cookbooks/test_helper/recipes/create_file.rb
@@ -1,5 +1,6 @@
 # ensures that the file defined by attributes exists, so its associated profile will pass
+file_path = node['audit']['inputs']['test_file_path'] || node['audit']['attributes']['test_file_path']
 
-file node['audit']['inputs']['test_file_path'] do
+file file_path do
   action :create
 end

--- a/test/integration/inputs-legacy/default.rb
+++ b/test/integration/inputs-legacy/default.rb
@@ -1,0 +1,19 @@
+# get most recent json-file output
+json_file = command('ls -t /tmp/inspec-*.json').stdout.lines.first.chomp
+
+# ensure the control we expect is present and passed
+controls = json(json_file).profiles.first['controls']
+results = []
+controls.each do |c|
+  c['results'].each do |r|
+    results << r
+  end
+end
+input_control = results.find { |x| x['code_desc'] == 'File /opt/kitchen/cache/file-exists.test is expected to exist' }
+input_control = {} if input_control.nil?
+
+describe 'input control' do
+  it 'status should be passed' do
+    expect(input_control['status']).to eq('passed')
+  end
+end

--- a/test/integration/inputs/default.rb
+++ b/test/integration/inputs/default.rb
@@ -9,11 +9,11 @@ controls.each do |c|
     results << r
   end
 end
-attribute_control = results.find { |x| x['code_desc'] == 'File /opt/kitchen/cache/attribute-file-exists.test should exist' }
-attribute_control = {} if attribute_control.nil?
+input_control = results.find { |x| x['code_desc'] == 'File /opt/kitchen/cache/file-exists.test is expected to exist' }
+input_control = {} if input_control.nil?
 
-describe 'attribute control' do
+describe 'input control' do
   it 'status should be passed' do
-    expect(attribute_control['status']).to eq('passed')
+    expect(input_control['status']).to eq('passed')
   end
 end


### PR DESCRIPTION
### Description

As one of the last remaining parts of the renaming of InSpec Attributes to Inputs, this PR renames the `default['audit']['attributes']` chef infra attribute to `default['audit']['inputs']`. 

`default['audit']['attributes']` is retained, but any values set there are merged into `default['audit']['inputs']` and a warning is emitted.

Additionally, the attributes 
`node['audit']['attributes_save']` has been renamed to `node['audit']['inputs_save']` and 
`node['audit']['chef_node_attribute_enabled']` to `node['audit']['chef_node_input_enabled']`. At this time no backwards compatibility is in place for these two features, but that could be added if desired.

Should this be on a major release?

### Issues Resolved

Fixes #360

Also gets the attributes test suite passing, which had been failing.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
