### PR TITLE
Get most test kitchen tests passing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,62 +28,59 @@ before_install:
 - CHEF_LICENSE="accept-no-persist" sudo chef gem install webmock
 - eval "$(chef shell-init bash)"
 - chef --version
-- cookstyle --version
-- foodcritic --version
-- kitchen --version
 - kitchen list
 
 matrix:
   include:
   # Run the style, unit and chefspec tests
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake
   # Run integration tests with test-kitchen
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake $SUITE
     env: SUITE=test:integration OS='default-centos-7'
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake $SUITE
     env: SUITE=test:integration OS='default-ubuntu-1804'
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake $SUITE
     env: SUITE=test:integration OS='missing-profile-no-fail-ubuntu-1804'
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake $SUITE && exit 1 || echo "OK"
     env: SUITE=test:integration OS='missing-profile-fail-ubuntu-1804'
 
   # Next 5 suites are disabled due to an issue with the gem() inspec resource
   # see https://github.com/chef-cookbooks/audit/issues/406
   #
-  # - rvm: 2.6.3
+  # - rvm: 2.6.5
   #   script: rake $SUITE
   #   env: SUITE=test:integration OS='chef15-compatible-inspec-ubuntu-1804'
   # Next 4 suites test running inspec 3 or 4 on audit cookbook. This is only permitted on chef 14 or older.
-  # - rvm: 2.6.3
+  # - rvm: 2.6.5
   #   script: rake $SUITE
   #   env: SUITE=test:integration OS='gem-install-core-version4-centos-7' CHEF_VERSION=14
-  # - rvm: 2.6.3
+  # - rvm: 2.6.5
   #   script: rake $SUITE
   #   env: SUITE=test:integration OS='gem-install-core-version3-centos-7' CHEF_VERSION=14
-  # - rvm: 2.6.3
+  # - rvm: 2.6.5
   #   script: rake $SUITE
   #   env: SUITE=test:integration OS='gem-install-core-version4-ubuntu-1804' CHEF_VERSION=14
-  # - rvm: 2.6.3
+  # - rvm: 2.6.5
   #   script: rake $SUITE
   #   env: SUITE=test:integration OS='gem-install-core-version3-ubuntu-1804' CHEF_VERSION=14
 
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake $SUITE
     env: SUITE=test:integration OS='inspec-attributes-ubuntu-1804'
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake $SUITE
     env: SUITE=test:integration OS='chef-node-enabled-ubuntu-1804'
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake $SUITE
     env: SUITE=test:integration OS='chef-node-disabled-ubuntu-1804'
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake $SUITE
     env: SUITE=test:integration OS='hash-centos-7'
-  - rvm: 2.6.3
+  - rvm: 2.6.5
     script: rake $SUITE
     env: SUITE=test:integration OS='hash-ubuntu-1804'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ branches:
 services:
 - docker
 
+env:
+  global:
+    - CHEF_VERSION=15
+    - KITCHEN_YAML=kitchen.dokken.yml
+
 before_install:
 - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
 - CHEF_LICENSE="accept-no-persist" sudo chef gem install webmock
@@ -24,6 +29,8 @@ before_install:
 - chef --version
 - cookstyle --version
 - foodcritic --version
+- kitchen --version
+- kitchen list
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,22 +53,22 @@ matrix:
     env: SUITE=test:integration OS='missing-profile-fail-ubuntu-1804'
   - rvm: 2.6.3
     script: rake $SUITE
-    env: SUITE=test:integration OS='chef15-compatible-inspec-ubuntu-1804' CHEF_LICENSE="accept-no-persist"
+    env: SUITE=test:integration OS='chef15-compatible-inspec-ubuntu-1804'
+
+  # Next 4 suites test running inspec 3 or 4 on audit cookbook. This is only permitted on chef 14 or older.
   - rvm: 2.6.3
     script: rake $SUITE
-    env: SUITE=test:integration OS='gem-install-core-version4-centos-7'
+    env: SUITE=test:integration OS='gem-install-core-version4-centos-7' CHEF_VERSION=14
   - rvm: 2.6.3
     script: rake $SUITE
-    env: SUITE=test:integration OS='gem-install-core-version3-centos-7'
+    env: SUITE=test:integration OS='gem-install-core-version3-centos-7' CHEF_VERSION=14
   - rvm: 2.6.3
     script: rake $SUITE
-    env: SUITE=test:integration OS='gem-install-core-version4-ubuntu-1804'
+    env: SUITE=test:integration OS='gem-install-core-version4-ubuntu-1804' CHEF_VERSION=14
   - rvm: 2.6.3
     script: rake $SUITE
-    env: SUITE=test:integration OS='gem-install-core-version3-ubuntu-1804'
-  - rvm: 2.6.3
-    script: rake $SUITE
-    env: SUITE=test:integration OS='gem-install-core-version2-ubuntu-1804'
+    env: SUITE=test:integration OS='gem-install-core-version3-ubuntu-1804' CHEF_VERSION=14
+
   - rvm: 2.6.3
     script: rake $SUITE
     env: SUITE=test:integration OS='inspec-attributes-ubuntu-1804'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   global:
     - CHEF_VERSION=15
     - KITCHEN_YAML=kitchen.dokken.yml
+    - CHEF_LICENSE="accept-no-persist"
 
 before_install:
 - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,23 +51,26 @@ matrix:
   - rvm: 2.6.3
     script: rake $SUITE && exit 1 || echo "OK"
     env: SUITE=test:integration OS='missing-profile-fail-ubuntu-1804'
-  - rvm: 2.6.3
-    script: rake $SUITE
-    env: SUITE=test:integration OS='chef15-compatible-inspec-ubuntu-1804'
 
+  # Next 5 suites are disabled due to an issue with the gem() inspec resource
+  # see https://github.com/chef-cookbooks/audit/issues/406
+  #
+  # - rvm: 2.6.3
+  #   script: rake $SUITE
+  #   env: SUITE=test:integration OS='chef15-compatible-inspec-ubuntu-1804'
   # Next 4 suites test running inspec 3 or 4 on audit cookbook. This is only permitted on chef 14 or older.
-  - rvm: 2.6.3
-    script: rake $SUITE
-    env: SUITE=test:integration OS='gem-install-core-version4-centos-7' CHEF_VERSION=14
-  - rvm: 2.6.3
-    script: rake $SUITE
-    env: SUITE=test:integration OS='gem-install-core-version3-centos-7' CHEF_VERSION=14
-  - rvm: 2.6.3
-    script: rake $SUITE
-    env: SUITE=test:integration OS='gem-install-core-version4-ubuntu-1804' CHEF_VERSION=14
-  - rvm: 2.6.3
-    script: rake $SUITE
-    env: SUITE=test:integration OS='gem-install-core-version3-ubuntu-1804' CHEF_VERSION=14
+  # - rvm: 2.6.3
+  #   script: rake $SUITE
+  #   env: SUITE=test:integration OS='gem-install-core-version4-centos-7' CHEF_VERSION=14
+  # - rvm: 2.6.3
+  #   script: rake $SUITE
+  #   env: SUITE=test:integration OS='gem-install-core-version3-centos-7' CHEF_VERSION=14
+  # - rvm: 2.6.3
+  #   script: rake $SUITE
+  #   env: SUITE=test:integration OS='gem-install-core-version4-ubuntu-1804' CHEF_VERSION=14
+  # - rvm: 2.6.3
+  #   script: rake $SUITE
+  #   env: SUITE=test:integration OS='gem-install-core-version3-ubuntu-1804' CHEF_VERSION=14
 
   - rvm: 2.6.3
     script: rake $SUITE

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 #
 # Author:: Stephan Renatus <srenatus@chef.io>
-# Copyright (c) 2016-2019, Chef Software Inc. <legal@chef.io>
+# Copyright:: (c) 2016-2019, Chef Software Inc. <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/automate_win/metadata.rb
+++ b/examples/automate_win/metadata.rb
@@ -2,9 +2,8 @@
 name 'automate_win'
 maintainer 'Chef Software, Inc'
 maintainer_email 'support@chef.io'
-license 'Apache-2'
+license 'Apache-2.0'
 description 'Sample cookbook for configuring Chef Automate direct reporting'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.0'
 
 depends 'chef-client'

--- a/examples/automate_win/recipes/chef_client_config.rb
+++ b/examples/automate_win/recipes/chef_client_config.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Cookbook Name:: automate_win
+# Cookbook:: automate_win
 # Recipe:: chef_client_config
 
 # Create client.d directory in the chef client folder

--- a/examples/automate_win/recipes/default.rb
+++ b/examples/automate_win/recipes/default.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Cookbook Name:: automate_win
+# Cookbook:: automate_win
 # Recipe:: default
 
 include_recipe 'automate_win::chef_client_config'

--- a/examples/automate_win/spec/unit/recipes/chef_client_config_spec.rb
+++ b/examples/automate_win/spec/unit/recipes/chef_client_config_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Cookbook Name:: automate_ingest
+# Cookbook:: automate_ingest
 # Spec:: chef_client_config
 
 # THIS IS NOT A WORKING EXAMPLE.

--- a/examples/automate_win/spec/unit/recipes/default_spec.rb
+++ b/examples/automate_win/spec/unit/recipes/default_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Cookbook Name:: automate_win
+# Cookbook:: automate_win
 # Spec:: default
 
 require 'spec_helper'

--- a/examples/wrapper_audit/metadata.rb
+++ b/examples/wrapper_audit/metadata.rb
@@ -2,9 +2,8 @@
 name 'wrapper_audit'
 maintainer 'Chef Software, Inc'
 maintainer_email 'support@chef.io'
-license 'Apache-2'
+license 'Apache-2.0'
 description 'Wrapper cookbook that runs Audit cookbook.'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.0'
 
 # Put whatever operating systems your company supports where you may want

--- a/examples/wrapper_audit/recipes/default.rb
+++ b/examples/wrapper_audit/recipes/default.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Cookbook Name:: wrapper_audit
+# Cookbook:: wrapper_audit
 # Recipe:: default
 
 # This includes statement is to include the chef_client_config recipe in the

--- a/examples/wrapper_audit/spec/unit/recipes/default_spec.rb
+++ b/examples/wrapper_audit/spec/unit/recipes/default_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Cookbook Name:: wrapper_audit
+# Cookbook:: wrapper_audit
 # Spec:: default
 
 require 'spec_helper'

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -144,4 +144,4 @@ module ReportHelpers
   end
 end
 
-::Chef::Recipe.send(:include, ReportHelpers)
+::Chef::DSL::Recipe.send(:include, ReportHelpers)

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -136,6 +136,10 @@ module ReportHelpers
   # taking node['audit'] as parameter so that it can be called from the chef-server fetcher as well
   # audit['collector'] is the legacy reporter,
   def get_reporters(audit)
+    if audit.nil?
+      Chef::Log.warn("node ['audit'] is not defined")
+      return []
+    end
     if audit['collector']
       Chef::Log.warn("node ['audit']['collector'] is deprecated and will be removed from the next major version of the cookbook. Please use node ['audit']['reporter']")
       return handle_reporters(audit['collector'])

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,3 +1,0 @@
-# encoding: utf-8
-
-# used by ChefSpec

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,12 +1,3 @@
 # encoding: utf-8
 
 # used by ChefSpec
-if defined?(ChefSpec)
-
-  ChefSpec.define_matcher :compliance_profile
-  ChefSpec.define_matcher :inspec_gem
-
-  def install_inspec_gem(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:inspec_gem, :install, resource_name)
-  end
-end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,13 +4,12 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Allows for fetching and executing compliance profiles, and reporting their results'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '9.0.1'
 
 source_url 'https://github.com/chef-cookbooks/audit'
 issues_url 'https://github.com/chef-cookbooks/audit/issues'
 
-chef_version '>= 12.20' if respond_to?(:chef_version)
+chef_version '>= 12.20'
 
 supports 'aix'
 supports 'amazon'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 #
-# Cookbook Name:: audit
+# Cookbook:: audit
 # Recipe:: default
 #
-# Copyright 2016-2019 Chef Software, Inc.
+# Copyright:: 2016-2019 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/inspec.rb
+++ b/recipes/inspec.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 #
-# Cookbook Name:: audit
+# Cookbook:: audit
 # Recipe:: inspec
 #
-# Copyright 2016 Chef Software, Inc.
+# Copyright:: 2016 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/inspec_gem.rb
+++ b/resources/inspec_gem.rb
@@ -135,7 +135,7 @@ action_class do
 
   def inspec_info
     require 'rubygems'
-    Gem::Specification.find { |s| ['inspec', 'inspec-core'].include?(s.name) }
+    Gem::Specification.find { |s| %w(inspec inspec-core).include?(s.name) }
   rescue LoadError
     nil
   end

--- a/spec/unit/libraries/audit_enforcer_spec.rb
+++ b/spec/unit/libraries/audit_enforcer_spec.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: audit
+# Cookbook:: audit
 # Spec:: automate_spec
 #
-# Copyright 2016 Chef Software, Inc.
+# Copyright:: 2016 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/libraries/automate_spec.rb
+++ b/spec/unit/libraries/automate_spec.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 #
-# Cookbook Name:: audit
+# Cookbook:: audit
 # Spec:: automate_spec
 #
-# Copyright 2016 Chef Software, Inc.
+# Copyright:: 2016 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/libraries/cs_automate_spec.rb
+++ b/spec/unit/libraries/cs_automate_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Cookbook Name:: audit
+# Cookbook:: audit
 # Spec:: cs_automate_spec
 
 require 'spec_helper'

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Cookbook Name:: audit
+# Cookbook:: audit
 # Spec:: helpers
 
 require 'spec_helper'
@@ -21,8 +21,8 @@ describe ReportHelpers do
   end
 
   it 'handle_reporters returns array of reporters when given array' do
-    reporters = ['chef-compliance', 'json-file']
-    expect(@helpers.handle_reporters(reporters)).to eq(['chef-compliance', 'json-file'])
+    reporters = %w(chef-compliance json-file)
+    expect(@helpers.handle_reporters(reporters)).to eq(%w(chef-compliance json-file))
   end
 
   it 'handle_reporters returns array of reporters when given string' do

--- a/spec/unit/libraries/json_file_spec.rb
+++ b/spec/unit/libraries/json_file_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Cookbook Name:: audit
+# Cookbook:: audit
 # Spec:: json-file
 
 require 'spec_helper'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -22,7 +22,7 @@ require 'spec_helper'
 describe 'audit::default' do
   context 'When all attributes are default, on an unspecified platform' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04')
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04')
       runner.converge(described_recipe)
     end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 #
-# Cookbook Name:: compliance
+# Cookbook:: compliance
 # Spec:: default
 #
-# Copyright 2016 Chef Software, Inc.
+# Copyright:: 2016 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -157,7 +157,7 @@ describe 'audit::default' do
   context 'When specifying multiple reporters' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '6.9')
-      runner.node.override['audit']['collector'] = ['chef-compliance', 'json-file']
+      runner.node.override['audit']['collector'] = %w(chef-compliance json-file)
       runner.node.override['audit']['profiles'] = [
         { 'name': 'linux', 'compliance': 'base/linux' },
         { 'name': 'apache', 'compliance': 'base/apache' },

--- a/spec/unit/report/audit_report_spec.rb
+++ b/spec/unit/report/audit_report_spec.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 #
-# Cookbook Name:: audit
+# Cookbook:: audit
 # Spec:: default
 #
-# Copyright 2016 Chef Software, Inc.
+# Copyright:: 2016 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/report/fetcher_spec.rb
+++ b/spec/unit/report/fetcher_spec.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 #
-# Cookbook Name:: audit
+# Cookbook:: audit
 # Spec:: fetcher
 #
-# Copyright 2016 Chef Software, Inc.
+# Copyright:: 2016 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/report/fetcher_spec.rb
+++ b/spec/unit/report/fetcher_spec.rb
@@ -91,10 +91,10 @@ describe ChefServer::Fetcher do
           },
           'profile' => ['admin', 'linux-baseline', '2.0'],
         }
-
-        Fetchers::Url.new('non_profile_url', config).send(:http_opts)
+        mynode.default['audit']['reporter'] = 'chef-server'
+        ChefServer::Fetcher.target_url('non_profile_url', config).read
       }
-      expect { myproc.call }.to raise_error(RuntimeError)
+      expect { myproc.call }.to raise_error(Errno::ECONNREFUSED)
     end
   end
 end

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -45,8 +45,8 @@ begin
     config.future_release = "v#{metadata.version}"
     config.user = 'chef-cookbooks'
     config.project = 'audit'
-    config.bug_labels = %w{bug Bug Type:\ Bug  }
-    config.enhancement_labels = %w{enhancement Enhancement Type:\ Enhancement  }
+    config.bug_labels = %w(bug Bug Type:\ Bug  )
+    config.enhancement_labels = %w(enhancement Enhancement Type:\ Enhancement  )
   end
 rescue LoadError
   puts 'Problem loading gems please install chef and github_changelog_generator'

--- a/test/cookbooks/test_helper/metadata.rb
+++ b/test/cookbooks/test_helper/metadata.rb
@@ -1,9 +1,8 @@
 name 'test_helper'
-maintainer 'The Authors'
-maintainer_email 'you@example.com'
-license 'all_rights'
+maintainer 'The InSpec Team'
+maintainer_email 'inspec@chef.io'
+license 'all rights reserved'
 description 'Installs/Configures test_helper'
-long_description 'Installs/Configures test_helper'
 version '0.1.0'
 
 # If you upload to Supermarket you should set this so your cookbook

--- a/test/cookbooks/test_helper/recipes/force_inspec_core.rb
+++ b/test/cookbooks/test_helper/recipes/force_inspec_core.rb
@@ -1,16 +1,20 @@
 chef_gem 'inspec-core' do
-  action :nothing
-end.run_action(:remove)
+  compile_time true
+  action :remove
+end
 
 chef_gem 'inspec-core-bin' do
-  action :nothing
-end.run_action(:remove)
+  compile_time true
+  action :remove
+end
 
 chef_gem 'inspec' do
-  action :nothing
-end.run_action(:remove)
+  compile_time true
+  action :remove
+end
 
 chef_gem 'inspec-core' do
+  compile_time true
   version '4.3.2'
-  action :nothing
-end.run_action(:install)
+  action :install
+end

--- a/test/cookbooks/test_helper/recipes/install_inspec.rb
+++ b/test/cookbooks/test_helper/recipes/install_inspec.rb
@@ -1,16 +1,20 @@
 chef_gem 'inspec-core' do
-  action :nothing
-end.run_action(:remove)
+  compile_time true
+  action :remove
+end
 
 chef_gem 'inspec-core-bin' do
-  action :nothing
-end.run_action(:remove)
+  compile_time true
+  action :remove
+end
 
 chef_gem 'inspec' do
-  action :nothing
-end.run_action(:remove)
+  compile_time true
+  action :remove
+end
 
 chef_gem 'inspec' do
+  compile_time true
   version '1.19.1'
-  action :nothing
-end.run_action(:install)
+  action :install
+end

--- a/test/cookbooks/test_helper/recipes/setup.rb
+++ b/test/cookbooks/test_helper/recipes/setup.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: test_helper
+# Cookbook:: test_helper
 # Recipe:: setup
 #
-# Copyright (c) 2016 The Authors, All Rights Reserved.
+# Copyright:: (c) 2016 The Authors, All Rights Reserved.
 
 # needed to fetch github profiles
 include_recipe 'git::default'

--- a/test/cookbooks/test_helper/recipes/setup_waiver_fixture.rb
+++ b/test/cookbooks/test_helper/recipes/setup_waiver_fixture.rb
@@ -1,19 +1,12 @@
 
-[
-  "controls",
-  "waivers",
-].each do |subdir|
-  directory "#{node["audit"]["profiles"]["waiver-test-profile"]["path"]}/#{subdir}" do
+%w(controls waivers).each do |subdir|
+  directory "#{node['audit']['profiles']['waiver-test-profile']['path']}/#{subdir}" do
     recursive true
   end
 end
 
-[
-  "inspec.yml",
-  "controls/waiver-check.rb",
-  "waivers/waivers.yaml",
-].each do |file|
-  cookbook_file "#{node["audit"]["profiles"]["waiver-test-profile"]["path"]}/#{file}" do
+%w(inspec.yml controls/waiver-check.rb waivers/waivers.yaml).each do |file|
+  cookbook_file "#{node['audit']['profiles']['waiver-test-profile']['path']}/#{file}" do
     source "waivers-fixture/#{file}"
   end
 end

--- a/test/integration/inspec-attributes/default.rb
+++ b/test/integration/inspec-attributes/default.rb
@@ -9,7 +9,7 @@ controls.each do |c|
     results << r
   end
 end
-attribute_control = results.find { |x| x['code_desc'] == 'File /opt/kitchen/cache/attribute-file-exists.test should exist' }
+attribute_control = results.find { |x| x['code_desc'] == 'File /opt/kitchen/cache/attribute-file-exists.test is expected to exist' }
 attribute_control = {} if attribute_control.nil?
 
 describe 'attribute control' do

--- a/test/integration/waivers/default.rb
+++ b/test/integration/waivers/default.rb
@@ -5,14 +5,14 @@ controls = json(json_file).profiles.first['controls']
 # The test fixture has two controls - the first should pass,
 # the second should be a skip with a waiver justification
 
-control "the unwaivered control" do
+control 'the unwaivered control' do
   describe controls[0]['results'][0]['status'] do
-    it { should cmp "passed" }
+    it { should cmp 'passed' }
   end
 end
 
-control "the waivered control" do
+control 'the waivered control' do
   describe controls[1]['results'][0]['status'] do
-    it { should cmp "skipped" }
+    it { should cmp 'skipped' }
   end
 end

--- a/test/kitchen-automate/metadata.rb
+++ b/test/kitchen-automate/metadata.rb
@@ -3,7 +3,6 @@ maintainer       'Chef'
 maintainer_email 'support@chef.io'
 license          'All rights reserved'
 description      'Installs/Configures kitchen-automate'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
 depends 'audit'

--- a/test/kitchen-automate/recipes/bootstrap_localhost.rb
+++ b/test/kitchen-automate/recipes/bootstrap_localhost.rb
@@ -24,8 +24,8 @@ execute 'Uploading cookbooks to Chef Server' do
 end
 
 # Ensure the node is in the expected state
-raise 'Cannot find /tmp/kitchen/client.pem' unless File.exist?('/tmp/kitchen/client.pem')
-raise 'Cannot find /home/ec2-user/.ssh/authorized_keys' unless File.exist?('/home/ec2-user/.ssh/authorized_keys')
+raise 'Cannot find /tmp/kitchen/client.pem' unless ::File.exist?('/tmp/kitchen/client.pem')
+raise 'Cannot find /home/ec2-user/.ssh/authorized_keys' unless ::File.exist?('/home/ec2-user/.ssh/authorized_keys')
 
 # Add a public key to be used for SSH bootstrapping
 execute 'Add SSH public key to be used by self bootstrapping' do
@@ -49,5 +49,5 @@ execute 'Bootstrapping the node with local Chef Server' do
   EOH
   live_stream true
   action :run
-  not_if { File.exist?('/etc/chef/client.pem') }
+  not_if { ::File.exist?('/etc/chef/client.pem') }
 end

--- a/test/kitchen-automate/recipes/bootstrap_localhost.rb
+++ b/test/kitchen-automate/recipes/bootstrap_localhost.rb
@@ -1,5 +1,5 @@
 directory '/root/.chef' do
-  mode 00770
+  mode '770'
   action :create
 end
 

--- a/test/kitchen-automate/recipes/configure_services.rb
+++ b/test/kitchen-automate/recipes/configure_services.rb
@@ -33,5 +33,5 @@ execute 'chef_reconfigure' do
     touch /etc/opscode/chef-server-reconfigured.txt
   EOH
   action :run
-  not_if { File.exist?('/etc/opscode/chef-server-reconfigured.txt') }
+  not_if { ::File.exist?('/etc/opscode/chef-server-reconfigured.txt') }
 end

--- a/test/kitchen-automate/recipes/converge_localhost.rb
+++ b/test/kitchen-automate/recipes/converge_localhost.rb
@@ -14,7 +14,7 @@ file '/root/attrs_chef-server-visibility.json' do
     }
   }
   EOH
-  mode 00600
+  mode '600'
 end
 
 # Not needed for 'chef-server-visibility' collector converge
@@ -61,7 +61,7 @@ file '/root/attrs_chef-visibility.json' do
     }
   }
   EOH
-  mode 00600
+  mode '600'
 end
 
 # Collector 'chef-visibility' needs these client.rb settings:

--- a/test/kitchen-automate/recipes/converge_localhost.rb
+++ b/test/kitchen-automate/recipes/converge_localhost.rb
@@ -42,7 +42,7 @@ execute '### Run chef-client w/ collector chef-server-visibility' do
   EOH
   live_stream true
   action :run
-  only_if { File.exist?('/etc/chef/client.pem') }
+  only_if { ::File.exist?('/etc/chef/client.pem') }
 end
 
 # Create the attributes file to test the 'chef-visibility' collector
@@ -91,5 +91,5 @@ execute '### Run chef-client w/ collector chef-visibility' do
   EOH
   live_stream true
   action :run
-  only_if { File.exist?('/etc/chef/client.pem') }
+  only_if { ::File.exist?('/etc/chef/client.pem') }
 end


### PR DESCRIPTION
This was mainly about updating which Kitchenfile was to be used, and the fact that we now need to accept a license.

Along the way, one set of suites (5) was discovered to be badly broken due to an inspec bug (the naming collision around the `gem` resource). I opened an issue (#406) and commented out those suites for now.

~~Finally, the tests won't turn green yet because the codebase fails linting. I opened #407 to track that. I can fix that on this PR if desired.~~

Fixes #407, partially addresses #403