### PR TITLE
Error: The `Style/BracesAroundHashParameters` cop has been removed.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,3 @@ Naming/AccessorMethodName:
   Exclude:
     - 'examples/chef-server/Vagrantfile'
     - 'spec/unit/report/audit_report_spec.rb'
-
-Style/BracesAroundHashParameters:
-  Enabled: false


### PR DESCRIPTION
Signed-off-by: Jason Field <jason@avon-lea.co.uk>

### Description

Error: The `Style/BracesAroundHashParameters` cop has been removed.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
