### PR TITLE
Update warnings on size limits, error on nil uuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     sources:
       - chef-current-xenial
     packages:
-      - chefdk
+      - chef-workstation
 
 # Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
 
 env:
   global:
-    - CHEF_VERSION=15
+    - CHEF_VERSION=15.8.23
     - KITCHEN_YAML=kitchen.dokken.yml
     - CHEF_LICENSE="accept-no-persist"
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -48,7 +48,7 @@ In the event of a malformed or unset token, the Chef Compliance server will log 
 
 ### 413 Request Entity Too Large
 
-If the `audit` cookbook report handler prints this stacktrace:
+If the `audit` cookbook report handler prints this stacktrace and you are using the `chef-server-automate` reporter:
 ```
 Running handlers:
 [2017-12-21T16:21:15+00:00] WARN: Compliance report size is 1.71 MB.
@@ -60,15 +60,17 @@ Running handlers:
 ...
 ```
 
-and the Chef Server Nginx logs confirm the `413` error:
+and the Chef Infra Server Nginx logs confirm the `413` error:
 ```
 ==> /var/log/opscode/nginx/access.log <==
 192.168.56.40 - - [21/Dec/2017:11:35:30 +0000]  "POST /organizations/eu_org/data-collector HTTP/1.1" 413 "0.803" 64 "-" "Chef Client/13.6.4 (ruby-2.4.2-p198; ohai-13.6.0; x86_64-linux; +https://chef.io)" "-" "-" "-" "13.6.4" "algorithm=sha1;version=1.1;" "bootstrapped-node" "2017-12-21T11:35:31Z" "GR6RyPvKkZDaGyQDYCPfoQGS8G4=" 1793064
 ```
 
-you most likely hit the `erchef` request size in Chef Server that defaults to ~1MB. To double this limit, add the following line in Chef Server's `/etc/opscode/chef-server.rb`:
+you most likely hit the `erchef` request size in Chef Infra Server. Prior to Infra Server 13.0, the default was ~1MB. Infra Server 13.0 and later default to ~2MB.
+
+As an example, to set the limit to ~3MB, add the following line in Chef Server's `/etc/opscode/chef-server.rb`:
 ```
-opscode_erchef['max_request_size'] = 2000000
+opscode_erchef['max_request_size'] = 3000000
 ```
 and run `chef-server-ctl reconfigure` to apply this change.
 

--- a/files/default/handler/audit_report.rb
+++ b/files/default/handler/audit_report.rb
@@ -61,7 +61,7 @@ class Chef
         # detect if we run in a chef client with chef server
         load_chef_fetcher if reporters.include?('chef-server') ||
                              reporters.include?('chef-server-automate') ||
-                             %w{chef-server chef-server-automate}.include?(fetcher)
+                             %w(chef-server chef-server-automate).include?(fetcher)
 
         load_automate_fetcher if fetcher == 'chef-automate'
 

--- a/files/default/vendor/chef-server/fetcher.rb
+++ b/files/default/vendor/chef-server/fetcher.rb
@@ -125,7 +125,7 @@ module ChefServer
 
     def self.chef_server_fetcher?
       # TODO: harmonize with audit_report.rb load_chef_fetcher
-      %w{chef-server chef-server-compliance chef-server-visibility chef-server-automate}.include?(Chef.node.attributes['audit']['fetcher'])
+      %w(chef-server chef-server-compliance chef-server-visibility chef-server-automate).include?(Chef.node.attributes['audit']['fetcher'])
     end
 
     private

--- a/libraries/reporters/automate.rb
+++ b/libraries/reporters/automate.rb
@@ -46,8 +46,11 @@ module Reporter
 
       json_report = enriched_report(report).to_json
       report_size = json_report.bytesize
-      if report_size > 5 * 1024 * 1024
+      # Automate GRPC currently has a message limit of ~4MB
+      # https://github.com/chef/automate/issues/1417#issuecomment-541908157
+      if report_size > 4 * 1024 * 1024
         Chef::Log.warn "Compliance report size is #{(report_size / (1024 * 1024.0)).round(2)} MB."
+        Chef::Log.warn 'Automate has an internal 4MB limit that is not currently configurable.'
       end
 
       unless json_report

--- a/libraries/reporters/cs_automate.rb
+++ b/libraries/reporters/cs_automate.rb
@@ -27,10 +27,17 @@ module Reporter
     end
 
     def send_report(report)
+      unless @entity_uuid && @run_id
+        Chef::Log.error "entity_uuid(#{@entity_uuid}) or run_id(#{@run_id}) can't be nil, not sending report to Chef Automate"
+        return false
+      end
+
       automate_report = enriched_report(report)
       report_size = automate_report.to_json.bytesize
+      # this is set to slightly less than the oc_erchef limit
       if report_size > 900 * 1024
         Chef::Log.warn "Compliance report size is #{(report_size / (1024 * 1024.0)).round(2)} MB."
+        Chef::Log.warn 'Infra Server < 13.0 defaults to a limit of ~1MB, 13.0+ defaults to a limit of ~2MB.'
       end
 
       if @insecure

--- a/spec/unit/libraries/audit_enforcer_spec.rb
+++ b/spec/unit/libraries/audit_enforcer_spec.rb
@@ -39,11 +39,11 @@ describe 'Reporter::ChefAutomate methods' do
   end
 
   it 'is not raising error for an InSpec report with no controls' do
-    expect(@automate.send_report({ "profiles": [{ "name": 'empty' }] })).to eq(true)
+    expect(@automate.send_report("profiles": [{ "name": 'empty' }])).to eq(true)
   end
 
   it 'is not raising error for an InSpec report with controls but no results' do
-    expect(@automate.send_report({ "profiles": [{ "controls": [{ "id": 'empty' }] }] })).to eq(true)
+    expect(@automate.send_report("profiles": [{ "controls": [{ "id": 'empty' }] }])).to eq(true)
   end
 
   it 'raises an error for a failed InSpec report' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -183,10 +183,10 @@ describe 'audit::default' do
       runner.converge(described_recipe)
     end
     it 'still contains the audit attributes after converge' do
-      expect(chef_run.node.attributes['audit']['attributes']).to eq({ 'my-inspec-attribute' => 'ok' })
+      expect(chef_run.node.attributes['audit']['attributes']).to eq('my-inspec-attribute' => 'ok')
     end
     it 'should contain the inspec attributes in the run_state' do
-      expect(chef_run.node.run_state['audit_attributes']).to eq({ 'my-inspec-attribute' => 'ok' })
+      expect(chef_run.node.run_state['audit_attributes']).to eq('my-inspec-attribute' => 'ok')
     end
     it 'should not raise an exception' do
       expect { chef_run }.to_not raise_error
@@ -204,7 +204,7 @@ describe 'audit::default' do
       expect(chef_run.node.attributes['audit']['attributes']).to eq(nil)
     end
     it 'should contain the inspec attributes in the run_state' do
-      expect(chef_run.node.run_state['audit_attributes']).to eq({ 'my-inspec-attribute' => 'ok' })
+      expect(chef_run.node.run_state['audit_attributes']).to eq('my-inspec-attribute' => 'ok')
     end
     it 'should not raise an exception' do
       expect { chef_run }.to_not raise_error

--- a/test/cookbooks/test_helper/files/waivers-fixture/controls/waiver-check.rb
+++ b/test/cookbooks/test_helper/files/waivers-fixture/controls/waiver-check.rb
@@ -2,15 +2,15 @@
 # Some of these controls are waivered by the file waivers/waivers.yaml
 
 # control-01 is normal, should pass
-control "control-01" do
-  describe "the expected value" do
-    it { should cmp "the expected value" }
+control 'control-01' do
+  describe 'the expected value' do
+    it { should cmp 'the expected value' }
   end
 end
 
 # control-02 is permanently waivered, should be skipped
-control "control-02" do
-  describe "the expected value" do
-    it { should cmp "the expected value" }
+control 'control-02' do
+  describe 'the expected value' do
+    it { should cmp 'the expected value' }
   end
 end


### PR DESCRIPTION
- The default Infra Server limit is 2mb as of 13.0
- Add a failiure to the cs_automate reporter on a nil uuid that matches the automate reporter
- Cookstyle fixes 