### PR TITLE
Report even on inspec runtime exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ vendor/
 .coverage/
 .zero-knife.rb
 Policyfile.lock.json
+chef_guid
+local-mode-cache/
 
 # vagrant stuff
 .vagrant/

--- a/spec/unit/report/audit_report_spec.rb
+++ b/spec/unit/report/audit_report_spec.rb
@@ -179,7 +179,7 @@ describe 'Chef::Handler::AuditReport methods' do
       report = @audit_report.call(opts, profiles)
       expect(report[:profiles].length).to eq(0)
       expect(report[:status]).to eq('failed')
-      expect(report[:platform]).to eq({:name=>"unknown", :release=>"unknown"})
+      expect(report[:platform]).to eq({ 'name': 'unknown', 'release': 'unknown' })
       expected_status_message = /^Cannot fetch all profiles.*does not exist$/
       expect(report[:status_message]).to match(expected_status_message)
     end
@@ -194,7 +194,7 @@ describe 'Chef::Handler::AuditReport methods' do
       report = @audit_report.call(opts, profiles)
       expect(report[:profiles].length).to eq(0)
       expect(report[:status]).to eq('failed')
-      expect(report[:platform]).to eq({:name=>"unknown", :release=>"unknown"})
+      expect(report[:platform]).to eq({ 'name': 'unknown', 'release': 'unknown' })
       expected_status_message = /^Client error. can't connect.*/
       expect(report[:status_message]).to match(expected_status_message)
     end


### PR DESCRIPTION
### Description

Before this, InSpec exceptions caused by invalid profiles or invalid InSpec attributes that didn't produce a valid report were not being sent over to Automate / Chef-Server.

### Issues Resolved

Catches any InSpec runtime exception and generates a minimal failed json report.
