### PR TITLE
Add `inspec_waiver_file` resource to the Audit cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added `inspec_waiver_file` resource for adding and removing controls in a waiver file.
 - resolved cookstyle error: spec/unit/recipes/default_spec.rb:40:7 warning: `ChefDeprecations/DeprecatedChefSpecPlatform`
 - resolved cookstyle error: spec/unit/recipes/default_spec.rb:56:7 warning: `ChefDeprecations/DeprecatedChefSpecPlatform`
 - resolved cookstyle error: spec/unit/recipes/default_spec.rb:72:7 warning: `ChefDeprecations/DeprecatedChefSpecPlatform`

--- a/README.md
+++ b/README.md
@@ -129,9 +129,64 @@ default['audit']['attributes'] = {
 }
 ```
 
-#### Waivers
+### Waivers
 
 You can use Chef InSpec's [Waiver Feature](https://www.inspec.io/docs/reference/waivers/) to mark individual failing controls as being administratively accepted, either on a temporary or permanent basis. Prepare a waiver YAML file, and use your Chef Infra cookbooks to deliver the file to your converging node (for example, using [cookbook_file](https://docs.chef.io/resource_cookbook_file.html) or [remote_file](https://docs.chef.io/resource_remote_file.html)). Then set the attribute `default['audit']['waiver_file']` to the location of the waiver file on the local node, and Chef InSpec will apply the waivers.
+
+### `inspec_waiver_file` resource
+
+Added in 9.6.0
+
+Use the **inspec_waiver_file** resource to add or remove entries from an inspec waiver file. This can be used in conjunction with the audit cookbook
+
+#### Actions
+
+- `:add` - adds a control to the inspec waiver file.
+- `:remove` - removes a control from the inspec waiver file.
+
+#### Properties
+
+- `control` - the name of the control to be waived when utilizing the inspec waiver file
+- `file` - the path to the inspec waiver file
+- `expiration` - The expiration date of a given waiver, provided in YYY-MM-DD format.
+- `run_test` - If set to true, the control will still run and be reported on, though it won't count as a negative or positive result of the inspec scan
+- `justification` - Text to add to the waiver for a control to explain why a waiver was added.
+- `backup` - By default, set to false, but if you supply an integer, this will ensure that that number of backups are retained in your chef backup location (`/var/chef/backup` on Unix and Linux platforms, `C:\chef\backup` on Windows platforms).
+
+#### Examples
+
+**Add an InSpec waiver entry to a given waiver file**:
+
+```ruby
+  inspec_waiver_file 'Add waiver entry for control' do
+    file 'C:\\chef\\inspec_waiver.yml'
+    control 'my_inspec_control_01'
+    run_test false
+    justification "The subject of this control is not managed by Chef on the systems in policy group \#{node['policy_group']}"
+    expiration '2021-01-01'
+    action :add
+  end
+```
+
+**Add an InSpec waiver entry to a given waiver file using the 'name' property to identify the control**:
+
+```ruby
+  inspec_waiver_file 'my_inspec_control_01' do
+    file 'C:\\chef\\inspec_waiver.yml'
+    justification "The subject of this control is not managed by Chef on the systems in policy group \#{node['policy_group']}"
+    action :add
+  end
+```
+
+**Remove an InSpec waiver entry to a given waiver file**:
+
+```ruby
+  inspec_waiver_file "my_inspec_control_01" do
+    file '/etc/chef/inspec_waiver.yml'
+    action :remove
+  end
+```
+
 
 ### Reporting
 

--- a/resources/inspec_waiver_file.rb
+++ b/resources/inspec_waiver_file.rb
@@ -1,4 +1,6 @@
 require 'yaml'
+require 'date'
+
 provides :inspec_waiver_file
 unified_mode true
 
@@ -16,12 +18,7 @@ property :expiration, String,
   description: 'The expiration date of the given waiver - provided in YYYY-MM-DD format',
   callbacks: {
     'Expiration date should match the following format: YYYY-MM-DD' => proc { |e|
-      re = Regexp.new('([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))').freeze
-      if re.match?(e) || e.nil?
-        true
-      else
-        false
-      end
+      Date.valid_date?(*e.split('-').map(&:to_i))
     },
   }
 
@@ -31,41 +28,44 @@ property :run_test, [true, false],
 property :justification, String,
   description: 'Can be any text you want and might include a reason for the waiver as well as who signed off on the waiver.'
 
-property :backup, [false, Integers],
+property :backup, [false, Integer],
   description: 'The number of backups to be kept in /var/chef/backup (for UNIX- and Linux-based platforms) or C:/chef/backup (for the Microsoft Windows platform). Set to false to prevent backups from being kept.',
   default: false
 
 action :add do
   filename = new_resource.file
-  yaml_contents = if ::File.file?(filename) && ::File.readable?(filename) && !::File.zero?(filename)
-                    IO.read(new_resource.file)
-                  else
-                    ''
-                  end
-  waiver_hash = {}
-  waiver_hash = ::YAML.safe_load(yaml_contents) unless yaml_contents.empty?
+  waiver_hash = load_waiver_file_to_hash(filename)
   control_hash = {}
   control_hash['expiration_date'] = new_resource.expiration.to_s unless new_resource.expiration.nil?
   control_hash['run'] = new_resource.run_test unless new_resource.run_test.nil?
   control_hash['justification'] = new_resource.justification.to_s
 
-  if waiver_hash.key?("#{new_resource.control}")
-    unless waiver_hash["#{new_resource.control}"] == control_hash
-      waiver_hash["#{new_resource.control}"] = {}
-      waiver_hash["#{new_resource.control}"] = control_hash
-      waiver_hash = waiver_hash.sort.to_h
-      file "Update Waiver File #{new_resource.file} to update waiver for control #{new_resource.control}" do
-        path new_resource.file
-        content waiver_hash.to_yaml
-        backup new_resource.backup
-        action :create
-      end
+  if waiver_hash.key?(new_resource.control)
+    unless waiver_hash[new_resource.control] == control_hash
+      waiver_hash.delete(new_resource.control)
+      waiver_hash[new_resource.control] = control_hash
     end
   else
-    waiver_hash["#{new_resource.control}"] = {}
-    waiver_hash["#{new_resource.control}"] = control_hash
+    waiver_hash[new_resource.control] = control_hash
+  end
+
+  waiver_hash = waiver_hash.sort.to_h
+
+  file "Update Waiver File #{new_resource.file} to update waiver for control #{new_resource.control}" do
+    path new_resource.file
+    content waiver_hash.to_yaml
+    backup new_resource.backup
+    action :create
+  end
+end
+
+action :remove do
+  filename = new_resource.file
+  waiver_hash = load_waiver_file_to_hash(filename)
+  if waiver_hash.key?(new_resource.control)
+    waiver_hash.delete(new_resource.control)
     waiver_hash = waiver_hash.sort.to_h
-    file "Update Waiver File #{new_resource.file} to add waiver for control #{new_resource.control}" do
+    file "Update Waiver File #{new_resource.file} to remove waiver for control #{new_resource.control}" do
       path new_resource.file
       content waiver_hash.to_yaml
       backup new_resource.backup
@@ -74,20 +74,15 @@ action :add do
   end
 end
 
-action :remove do
-  filename = new_resource.file
-  if ::File.file?(filename) && ::File.readable?(filename) && !::File.zero?(filename)
-    yaml_contents = IO.read(filename)
-    waiver_hash = ::YAML.safe_load(yaml_contents)
-    if waiver_hash.key?("#{new_resource.control}")
-      waiver_hash.delete("#{new_resource.control}")
-      waiver_hash = waiver_hash.sort.to_h
-      file "Update Waiver File #{new_resource.file} to remove waiver for control #{new_resource.control}" do
-        path new_resource.file
-        content waiver_hash.to_yaml
-        backup new_resource.backup
-        action :create
-      end
+action_class do
+  def load_waiver_file_to_hash(file_name)
+    if ::File.file?(file_name) && ::File.readable?(file_name) && !::File.zero?(file_name)
+      file_contents = IO.read(file_name)
+      contents_hash = {}
+      contents_hash = ::YAML.safe_load(file_contents) unless file_contents.empty?
+    else
+      contents_hash = {}
     end
+    contents_hash
   end
 end

--- a/resources/inspec_waiver_file.rb
+++ b/resources/inspec_waiver_file.rb
@@ -1,0 +1,93 @@
+require 'yaml'
+provides :inspec_waiver_file
+unified_mode true
+
+description 'Use the **inspec_waiver_file** resource to add or remove entries from an inspec waiver file. This can be used in conjunction with the audit cookbook'
+
+property :control, String,
+  name_property: true,
+  description: 'The name of the control being added or removed to the waiver file'
+
+property :file, String,
+  required: true,
+  description: 'The path to the waiver file being modified'
+
+property :expiration, String,
+  description: 'The expiration date of the given waiver - provided in YYYY-MM-DD format',
+  callbacks: {
+    'Expiration date should match the following format: YYYY-MM-DD' => proc { |e|
+      re = Regexp.new('([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))').freeze
+      if re.match?(e) || e.nil?
+        true
+      else
+        false
+      end
+    },
+  }
+
+property :run_test, [true, false],
+  description: 'If present and true, the control will run and be reported, but failures in it won’t make the overall run fail. If absent or false, the control will not be run.'
+
+property :justification, String,
+  description: 'Can be any text you want and might include a reason for the waiver as well as who signed off on the waiver.'
+
+property :backup, [false, Integers],
+  description: 'The number of backups to be kept in /var/chef/backup (for UNIX- and Linux-based platforms) or C:/chef/backup (for the Microsoft Windows platform). Set to false to prevent backups from being kept.',
+  default: false
+
+action :add do
+  filename = new_resource.file
+  yaml_contents = if ::File.file?(filename) && ::File.readable?(filename) && !::File.zero?(filename)
+                    IO.read(new_resource.file)
+                  else
+                    ''
+                  end
+  waiver_hash = {}
+  waiver_hash = ::YAML.safe_load(yaml_contents) unless yaml_contents.empty?
+  control_hash = {}
+  control_hash['expiration_date'] = new_resource.expiration.to_s unless new_resource.expiration.nil?
+  control_hash['run'] = new_resource.run_test unless new_resource.run_test.nil?
+  control_hash['justification'] = new_resource.justification.to_s
+
+  if waiver_hash.key?("#{new_resource.control}")
+    unless waiver_hash["#{new_resource.control}"] == control_hash
+      waiver_hash["#{new_resource.control}"] = {}
+      waiver_hash["#{new_resource.control}"] = control_hash
+      waiver_hash = waiver_hash.sort.to_h
+      file "Update Waiver File #{new_resource.file} to update waiver for control #{new_resource.control}" do
+        path new_resource.file
+        content waiver_hash.to_yaml
+        backup new_resource.backup
+        action :create
+      end
+    end
+  else
+    waiver_hash["#{new_resource.control}"] = {}
+    waiver_hash["#{new_resource.control}"] = control_hash
+    waiver_hash = waiver_hash.sort.to_h
+    file "Update Waiver File #{new_resource.file} to add waiver for control #{new_resource.control}" do
+      path new_resource.file
+      content waiver_hash.to_yaml
+      backup new_resource.backup
+      action :create
+    end
+  end
+end
+
+action :remove do
+  filename = new_resource.file
+  if ::File.file?(filename) && ::File.readable?(filename) && !::File.zero?(filename)
+    yaml_contents = IO.read(filename)
+    waiver_hash = ::YAML.safe_load(yaml_contents)
+    if waiver_hash.key?("#{new_resource.control}")
+      waiver_hash.delete("#{new_resource.control}")
+      waiver_hash = waiver_hash.sort.to_h
+      file "Update Waiver File #{new_resource.file} to remove waiver for control #{new_resource.control}" do
+        path new_resource.file
+        content waiver_hash.to_yaml
+        backup new_resource.backup
+        action :create
+      end
+    end
+  end
+end

--- a/spec/unit/resource/inspec_waiver_file_spec.rb
+++ b/spec/unit/resource/inspec_waiver_file_spec.rb
@@ -1,0 +1,77 @@
+#
+# Author:: Cary Penniman (<cary@rightscale.com>)
+# Author:: Tyler Cloke (<tyler@chef.io>)
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe Chef::Resource::InspecWaiverFile do
+  let(:log_str) { 'this is my string to log' }
+  let(:resource) { Chef::Resource::InspecWaiverFile.new('fakey_fakerton') }
+
+  it 'has a name of inspec_waiver_file' do
+    expect(resource.resource_name).to eq(:inspec_waiver_file)
+  end
+
+  it 'setting the control property to a string does not raise error' do
+    expect { resource.control 'my_test_control' }.not_to raise_error
+  end
+
+  it 'sets the default action as :add' do
+    expect(resource.action).to eql([:add])
+  end
+
+  it 'supports :add action' do
+    expect { resource.action :add }.not_to raise_error
+  end
+
+  it 'supports :remove action' do
+    expect { resource.action :remove }.not_to raise_error
+  end
+
+  it 'expects expiration property to fail with date format YYYY/MM/DD' do
+    expect { resource.expiration '2022/09/23' }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+
+  it 'expects expiration property to match YYYY-MM-DD' do
+    expect { resource.expiration '2022-09-23' }.not_to raise_error
+  end
+
+  it 'expects the run_test property to fail validation when not a true/false value' do
+    expect { resource.run_test 'yes' }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+
+  it 'expects the run_test property to only accept true or false values' do
+    expect { resource.run_test true }.not_to raise_error
+  end
+
+  it 'expects the justification property to accept a string value' do
+    expect { resource.justification "Because I don't want to run this compliance test" }.not_to raise_error
+  end
+
+  it 'expects the justification property to fail if given a non-string value' do
+    expect { resource.justification true }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+
+  it 'expects the backup property to fail validation when set to true' do
+    expect { resource.backup true }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+
+  it 'expects the backup property to fail validation when passed a string' do
+    expect { resource.backup 'please' }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+end

--- a/spec/unit/resource/inspec_waiver_file_spec.rb
+++ b/spec/unit/resource/inspec_waiver_file_spec.rb
@@ -1,6 +1,5 @@
 #
-# Author:: Cary Penniman (<cary@rightscale.com>)
-# Author:: Tyler Cloke (<tyler@chef.io>)
+# Author:: Davin Taddeo (<davin@chef.io>)
 # Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
@@ -45,6 +44,10 @@ describe Chef::Resource::InspecWaiverFile do
 
   it 'expects expiration property to fail with date format YYYY/MM/DD' do
     expect { resource.expiration '2022/09/23' }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+
+  it 'expects expiration property to fail with invalid date 2022-02-31' do
+    expect { resource.expiration '2022-02-31' }.to raise_error(Chef::Exceptions::ValidationFailed)
   end
 
   it 'expects expiration property to match YYYY-MM-DD' do


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@chef.io>

There is a similar [PR for chef-client](https://github.com/chef/chef/pull/10098) that is under review/discussion.  If we choose to do something else with waiver files in chef-client, it would still be nice to have a resource in the audit cookbook that could manage waiver files.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Chef recently introduced the use of waiver files by InSpec, as well as use via the audit cookbook.  There isn't a corresponding chef-client resource to manage such a file through chef automation if a user wanted to.  This `inspec_waiver_file` resource will provide that functionality.

**Add an InSpec waiver entry to a given waiver file**:

  ```ruby
    inspec_waiver_file 'Add waiver entry for control' do
      file 'C:\\chef\\inspec_waiver.yml'
      control 'my_inspec_control_01'
      run_test false
      justification "The subject of this control is not managed by Chef on the systems in policy group \#{node['policy_group']}"
      expiration 2021-01-01
      action :add
    end
  ```

**Add an InSpec waiver entry to a given waiver file using the 'name' property to identify the control**:

  ```ruby
    inspec_waiver_file 'my_inspec_control_01' do
      file 'C:\\chef\\inspec_waiver.yml'
      justification "The subject of this control is not managed by Chef on the systems in policy group \#{node['policy_group']}"
      action :add
    end
  ```

**Remove an InSpec waiver entry to a given waiver file**:

  ```ruby
    inspec_waiver_file "my_inspec_control_01" do
      file '/etc/chef/inspec_waiver.yml'
      action :remove
    end
  ```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
